### PR TITLE
Add mapping for aws_lb_listener_rule

### DIFF
--- a/src/aws.go
+++ b/src/aws.go
@@ -103,6 +103,7 @@ func GetAWSResourcePermissions(result ResourceV2) ([]string, error) {
 		"aws_alb":                                            awsLb,
 		"aws_alb_listener":                                   awsLbListener,
 		"aws_lb_listener":                                    awsLbListener,
+		"aws_lb_listener_rule":                               awsLbListenerRule,
 		"aws_lb_target_group":                                awsLbTargetGroup,
 		"aws_alb_target_group":                               awsLbTargetGroup,
 		"aws_alb_target_group_attachment":                    awsLbTargetGroupAttachment,

--- a/src/files.go
+++ b/src/files.go
@@ -13,6 +13,9 @@ var awsLbTargetGroupAttachment []byte
 //go:embed mapping/aws/resource/elasticloadbalancing/aws_lb_listener.json
 var awsLbListener []byte
 
+//go:embed mapping/aws/resource/elasticloadbalancing/aws_lb_listener_rule.json
+var awsLbListenerRule []byte
+
 //go:embed mapping/aws/resource/elasticloadbalancing/aws_lb.json
 var awsLb []byte
 

--- a/src/mapping/aws/resource/elasticloadbalancing/aws_lb_listener_rule.json
+++ b/src/mapping/aws/resource/elasticloadbalancing/aws_lb_listener_rule.json
@@ -1,0 +1,24 @@
+[
+    {
+        "apply": [
+            "elasticloadbalancing:CreateRule",
+            "elasticloadbalancing:SetRulePriorities"
+        ],
+        "attributes": {
+            "tags": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:DescribeTags"
+            ]
+        },
+        "destroy": [
+            "elasticloadbalancing:DeleteRule"
+        ],
+        "modify": [
+            "elasticloadbalancing:ModifyRule"
+        ],
+        "plan": [
+            "elasticloadbalancing:DescribeRules"
+        ]
+    }
+]


### PR DESCRIPTION
I just discovered during tests of `pike` that it doesn't have mapping for listener rule, so I created one :) 