### PR TITLE
fix typo in policy, remove non-existent policy

### DIFF
--- a/src/mapping/aws/resource/ec2/aws_ec2_transit_gateway_route_table.json
+++ b/src/mapping/aws/resource/ec2/aws_ec2_transit_gateway_route_table.json
@@ -2,7 +2,7 @@
   {
     "apply": [
       "ec2:CreateTransitGatewayRouteTable",
-      "ec2:DescribeTransitGatewayRouteTable"
+      "ec2:DescribeTransitGatewayRouteTables"
     ],
     "attributes": {
       "tags": [


### PR DESCRIPTION
`ec2:DescribeTransitGatewayRouteTable` needs an ’s’ added at the end.