### PR TITLE
Add GCP resources

### DIFF
--- a/src/coverage/google.md
+++ b/src/coverage/google.md
@@ -2,7 +2,7 @@
 
 | Terraform  | Coverage % | Resources | Total Resources |
 |------------|------------|-----------|-----------------|
-| Resources  | 62.61      |   802       |  1281            |
+| Resources  | 62.76      |   804       |  1281            |
 | Datasource | 99.76      |   408       |   409             |
 
 ```shell
@@ -168,9 +168,7 @@
 ./resource.ps1 google_compute_resource_policy
 ./resource.ps1 google_compute_resource_policy_attachment
 ./resource.ps1 google_compute_route
-./resource.ps1 google_compute_router
 ./resource.ps1 google_compute_router_interface
-./resource.ps1 google_compute_router_nat
 ./resource.ps1 google_compute_router_nat_address
 ./resource.ps1 google_compute_router_peer
 ./resource.ps1 google_compute_router_route_policy

--- a/src/files_gcp.go
+++ b/src/files_gcp.go
@@ -589,6 +589,12 @@ var googleComputeNetworkEndpointGroup []byte
 //go:embed mapping/google/resource/compute/google_compute_project_metadata_item.json
 var googleComputeProjectMetadataItem []byte
 
+//go:embed mapping/google/resource/compute/google_compute_router.json
+var googleComputeRouter []byte
+
+//go:embed mapping/google/resource/compute/google_compute_router_nat.json
+var googleComputeRouterNat []byte
+
 //go:embed mapping/google/resource/compute/google_compute_region_backend_service.json
 var googleComputeRegionBackendService []byte
 

--- a/src/gcp.go
+++ b/src/gcp.go
@@ -325,6 +325,8 @@ var gCPTfLookup = map[string]interface{}{
 	"google_compute_network_attachment":                                      googleComputeNetworkAttachment,
 	"google_compute_network_endpoint_group":                                  googleComputeNetworkEndpointGroup,
 	"google_compute_project_metadata_item":                                   googleComputeProjectMetadataItem,
+	"google_compute_router":                                                  googleComputeRouter,
+	"google_compute_router_nat":                                              googleComputeRouterNat,
 	"google_compute_region_backend_service":                                  googleComputeRegionBackendService,
 	"google_compute_region_backend_service_iam_binding":                      googleComputeRegionBackendServiceIAMBinding,
 	"google_compute_region_backend_service_iam_member":                       googleComputeRegionBackendServiceIAMMember,

--- a/src/mapping/google/resource/compute/google_compute_router.json
+++ b/src/mapping/google/resource/compute/google_compute_router.json
@@ -1,0 +1,19 @@
+[
+  {
+    "apply": [
+      "compute.routers.create"
+    ],
+    "attributes": {
+      "tags": []
+    },
+    "destroy": [
+      "compute.routers.delete"
+    ],
+    "modify": [
+      "compute.routers.update"
+    ],
+    "plan": [
+      "compute.routers.get"
+    ]
+  }
+]

--- a/src/mapping/google/resource/compute/google_compute_router_nat.json
+++ b/src/mapping/google/resource/compute/google_compute_router_nat.json
@@ -1,0 +1,19 @@
+[
+  {
+    "apply": [
+      "compute.routers.create"
+    ],
+    "attributes": {
+      "tags": []
+    },
+    "destroy": [
+      "compute.routers.delete"
+    ],
+    "modify": [
+      "compute.routers.update"
+    ],
+    "plan": [
+      "compute.routers.get"
+    ]
+  }
+]


### PR DESCRIPTION
Add support for google_compute_router and google_compute_router_nat

- Added JSON mappings with required compute.routers.* permissions
- Updated resource lookup tables in gcp.go and files_gcp.go
- Coverage increased from 62.61% to 62.76% (804/1281 resources)

Previous output observed:
```
$ pike scan
10:18AM DBG not implemented google_compute_router
10:18AM DBG not implemented google_compute_router_nat
```