### PR TITLE
chore(ci): pin govulncheck action and source Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       ## this will contain a matrix of all the combinations
       ## we wish to test again:
       matrix:
-        go-version: [ 1.25.9 ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
 
     ## Defines the platform for each test run
@@ -24,20 +23,20 @@ jobs:
     ## the steps that will be run through for each version and platform
     ## combination
     steps:
+      ## checks out our code locally, so we can work with the files
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       ## sets up go based on the version
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
 
       - uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
           tofu_version: 1.8.8
           tofu_wrapper: false
-
-      ## checks out our code locally, so we can work with the files
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       ## cache the module download directory to avoid re-fetching deps every push
       - name: Restore cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7851e55dc3be31ec4bcc3ef98453de2cb306e698 # codeql-bundle-v2.25.3
+        uses: github/codeql-action/init@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +61,7 @@ jobs:
       - name: Autobuild
         env:
           GOTOOLCHAIN: auto
-        uses: github/codeql-action/autobuild@7851e55dc3be31ec4bcc3ef98453de2cb306e698 # codeql-bundle-v2.25.3
+        uses: github/codeql-action/autobuild@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -74,4 +74,4 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7851e55dc3be31ec4bcc3ef98453de2cb306e698 # codeql-bundle-v2.25.3
+        uses: github/codeql-action/analyze@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.9
+          go-version-file: go.mod
       - name: Restore cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -29,9 +29,11 @@ jobs:
         with:
           version: v2.12.1
       - name: govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: ""
+          go-version-file: go.mod
+          repo-checkout: false
       # gosec is available as a golangci-lint linter - enable it in
       # .golangci.yml once the baseline is clean rather than running it here.
   test:
@@ -39,7 +41,6 @@ jobs:
       GOTOOLCHAIN: auto
     strategy:
       matrix:
-        go-version: [ 1.25.9 ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -52,7 +53,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: Restore cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25
+          go-version-file: go.mod
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0

--- a/.github/workflows/resources.yml
+++ b/.github/workflows/resources.yml
@@ -12,10 +12,13 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       # Schema-based parse shells out to `terraform providers schema -json`,
       # so a tf binary needs to be on PATH. Installing it once here avoids
@@ -25,9 +28,6 @@ jobs:
         with:
           tofu_version: 1.8.8
           tofu_wrapper: false
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build
         run: go build -o ${{ github.workspace }} ./...

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,6 +28,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@7851e55dc3be31ec4bcc3ef98453de2cb306e698 # codeql-bundle-v2.25.3
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
         with:
           sarif_file: results.sarif

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,42 +1,51 @@
-# Config for golangci-lint. Pinned to v1.64.x in .github/workflows/pr.yml.
-
+version: "2"
 run:
-  timeout: 5m
   tests: true
-
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck      # unhandled errors
-    - govet         # correctness checks built into the toolchain
-    - ineffassign   # assignments that are never used
-    - staticcheck   # the big one: SA-series bug checks
-    - unused        # dead code
-    - gosimple      # simpler idiomatic forms
-    - typecheck     # compile-level sanity
-    - forbidigo     # enforce zerolog-only logging
-    - misspell      # catch typos in strings and comments
-
-linters-settings:
-  errcheck:
-    # Don't warn on well-known intentional ignores
-    exclude-functions:
-      - (io.Closer).Close
-      - (*os.File).Close
-      - fmt.Fprintln
-      - fmt.Fprintf
-      - fmt.Fprint
-  forbidigo:
-    forbid:
-      - p: ^log\.Print(f|ln)?$
-        msg: "use zerolog (log.Info/Warn/Error/Debug) instead of stdlib log"
-
+    - errcheck
+    - forbidigo
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - fmt.Fprintln
+        - fmt.Fprintf
+        - fmt.Fprint
+    forbidigo:
+      forbid:
+        - pattern: ^log\.Print(f|ln)?$
+          msg: use zerolog (log.Info/Warn/Error/Debug) instead of stdlib log
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - src/testdata
+      - src/mapping
+      - src/schema
+      - terraform
+      - venv
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-dirs:
-    - src/testdata
-    - src/mapping
-    - src/schema
-    - terraform
-    - venv
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -202,11 +202,11 @@ func deprecatedSection(data members) string {
 	if data.ProviderVersion != "" {
 		schemaRef = "provider schema v" + data.ProviderVersion
 	}
-	b.WriteString(fmt.Sprintf(
+	fmt.Fprintf(&b,
 		"%d resources and %d datasources are flagged as deprecated in %s. "+
 			"Users pinned to an older provider major may already be affected when they upgrade.\n\n",
 		len(data.DeprecatedResources), len(data.DeprecatedData), schemaRef,
-	))
+	)
 
 	if len(data.DeprecatedResources) > 0 {
 		b.WriteString("### Deprecated Resources\n\n")

--- a/src/data.go
+++ b/src/data.go
@@ -360,7 +360,7 @@ func GetPermission(result ResourceV2) (Sorted, error) {
 		"healthchecksio":
 		return myPermission, nil
 	default:
-		if result.Provider != "" && !(result.TypeName == "module") {
+		if result.Provider != "" && result.TypeName != "module" {
 			log.Info().Msgf("Provider %s was not found", result.Provider)
 		} else {
 			log.Info().Msgf("Provider %s Type %s not found", result.Provider, result.TypeName)

--- a/src/gitHub.go
+++ b/src/gitHub.go
@@ -116,7 +116,7 @@ func InvokeGithubDispatchEvent(repository string, workflowFileName string, branc
 	}
 
 	if err != nil {
-		log.Info().Msgf("invoke failed %s", response.Response.Status)
+		log.Info().Msgf("invoke failed %s", response.Status)
 
 		return &workflowInvokeError{err: err}
 	}


### PR DESCRIPTION
Replace `go install govulncheck@latest` with the SHA-pinned golang/govulncheck-action to close the unpinned-dependency code scanning alert and make it visible to ghat.

Switch all workflows to `go-version-file: go.mod` so the Go version is single-sourced. Reorder checkout before setup-go in ci.yml and resources.yml so go.mod is present when read. Drop the single-value go-version matrix dimension.

Includes ghat-driven SHA bumps for codeql-action.