### PR TITLE
chore(dev): add retry-iam tool and *-wait make targets; switch aws/azurerm to tofu

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jameswoolfenden/pike
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/JamesWoolfenden/arn v0.2.6

--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -4,24 +4,33 @@ clean:
 	-rm terraform.tfstate
 	-rm terraform.tfstate.backup
 apply: init
-	terraform apply -auto-approve
+	tofu apply -auto-approve
 
 plan: init
-	terraform plan
+	tofu plan
 
 destroy: init
-	terraform destroy -auto-approve
+	tofu destroy -auto-approve
+
+apply-wait: init
+	go run ../../tools/retry-iam tofu apply -auto-approve
+
+plan-wait: init
+	go run ../../tools/retry-iam tofu plan
+
+destroy-wait: init
+	go run ../../tools/retry-iam tofu destroy -auto-approve
 
 init:
-	terraform init
+	tofu init
 
 upgrade:
-	terraform init --upgrade
+	tofu init --upgrade
 
 update: upgrade
 
 role: FORCE
-	terraform  -chdir=./role apply -auto-approve
+	tofu -chdir=./role apply -auto-approve
 
 FORCE:
 
@@ -32,7 +41,7 @@ up: role sleep apply
 
 mac: role init
 	sleep 5
-	terraform apply -auto-approve
+	tofu apply -auto-approve
 
 bump:
 	$(eval VERSION=$(shell git describe --tags --abbrev=0 | awk -F. '{OFS="."; $$NF+=1; print $0}'))

--- a/terraform/azurerm/Makefile
+++ b/terraform/azurerm/Makefile
@@ -4,24 +4,33 @@ clean:
 	-rm terraform.tfstate
 	-rm terraform.tfstate.backup
 apply: init
-	terraform apply -auto-approve
+	tofu apply -auto-approve
 
 plan: init
-	TF_LOG=DEBUG terraform plan
+	TF_LOG=DEBUG tofu plan
 
 destroy: init
-	terraform destroy -auto-approve
+	tofu destroy -auto-approve
+
+apply-wait: init
+	go run ../../tools/retry-iam tofu apply -auto-approve
+
+plan-wait: init
+	go run ../../tools/retry-iam tofu plan
+
+destroy-wait: init
+	go run ../../tools/retry-iam tofu destroy -auto-approve
 
 init:
-	terraform init
+	tofu init
 
 upgrade:
-	terraform init --upgrade
+	tofu init --upgrade
 
 update: upgrade
 
 role: FORCE
-	terraform  -chdir=./role apply -auto-approve
+	tofu -chdir=./role apply -auto-approve
 
 FORCE:
 
@@ -31,7 +40,7 @@ up: role sleep apply
 
 mac: role init
 	sleep 5
-	terraform apply -auto-approve
+	tofu apply -auto-approve
 
 bump:
 	git push

--- a/terraform/google/Makefile
+++ b/terraform/google/Makefile
@@ -12,6 +12,15 @@ plan: init
 destroy: init
 	GOOGLE_BACKEND_CREDENTIALS=$(PIKE_GOOGLE_BACKEND_CREDENTIALS) tofu destroy -auto-approve
 
+apply-wait: init
+	GOOGLE_BACKEND_CREDENTIALS=$(PIKE_GOOGLE_BACKEND_CREDENTIALS) go run ../../tools/retry-iam tofu apply -auto-approve
+
+plan-wait: init
+	GOOGLE_BACKEND_CREDENTIALS=$(PIKE_GOOGLE_BACKEND_CREDENTIALS) go run ../../tools/retry-iam tofu plan
+
+destroy-wait: init
+	GOOGLE_BACKEND_CREDENTIALS=$(PIKE_GOOGLE_BACKEND_CREDENTIALS) go run ../../tools/retry-iam tofu destroy -auto-approve
+
 show: init
 	GOOGLE_BACKEND_CREDENTIALS=$(PIKE_GOOGLE_BACKEND_CREDENTIALS) tofu show
 

--- a/tools/retry-iam/main.go
+++ b/tools/retry-iam/main.go
@@ -1,0 +1,80 @@
+// retry-iam reruns a command while it fails with an IAM eventual-consistency
+// permission error (AWS or GCP). Any other failure exits immediately.
+//
+//	go run ./tools/retry-iam tofu apply -auto-approve
+//
+// Env tunables:
+//
+//	RETRY_IAM_ATTEMPTS  max attempts (default 12)
+//	RETRY_IAM_SLEEP     base sleep seconds, linear backoff capped at 30 (default 5)
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+var iamDenied = regexp.MustCompile(`(?i)Error 403|PERMISSION_DENIED|AccessDenied|AccessDeniedException|UnauthorizedOperation|AuthorizationFailed|is not authorized to perform|does not have .* (permission|authorization)`)
+
+func envInt(key string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(key)); err == nil && v > 0 {
+		return v
+	}
+	return def
+}
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "retry-iam: no command given")
+		os.Exit(2)
+	}
+
+	attempts := envInt("RETRY_IAM_ATTEMPTS", 12)
+	base := time.Duration(envInt("RETRY_IAM_SLEEP", 5)) * time.Second
+
+	for i := 1; ; i++ {
+		fmt.Printf("[retry-iam] attempt %d/%d: %v\n", i, attempts, args)
+
+		var buf bytes.Buffer
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+
+		err := cmd.Run()
+		if err == nil {
+			fmt.Printf("[retry-iam] success on attempt %d\n", i)
+			os.Exit(0)
+		}
+
+		rc := 1
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			rc = ee.ExitCode()
+		} else {
+			fmt.Fprintf(os.Stderr, "[retry-iam] failed to run %q: %v\n", args[0], err)
+			os.Exit(rc)
+		}
+
+		if !iamDenied.Match(buf.Bytes()) {
+			fmt.Printf("[retry-iam] non-IAM failure (exit %d), not retrying\n", rc)
+			os.Exit(rc)
+		}
+		if i >= attempts {
+			fmt.Printf("[retry-iam] still IAM-denied after %d attempts (exit %d)\n", attempts, rc)
+			os.Exit(rc)
+		}
+
+		sleep := min(base*time.Duration(i), 30*time.Second)
+		fmt.Printf("[retry-iam] IAM denial detected, sleeping %v\n", sleep)
+		time.Sleep(sleep)
+	}
+}


### PR DESCRIPTION
tools/retry-iam reruns a tofu command while it fails with an IAM eventual-consistency denial (GCP 403/PERMISSION_DENIED, AWS AccessDenied/ UnauthorizedOperation, Azure AuthorizationFailed), backing off up to 12 attempts, and exits immediately on any other error so real failures aren't masked. New apply-wait/plan-wait/destroy-wait targets in all three provider Makefiles call it via go run, replacing the fixed sleep-5 hacks. AWS and azurerm Makefiles also moved from terraform to tofu.