### PR TITLE
feat(aws): emit tag permissions when provider default_tags is set

### DIFF
--- a/src/data.go
+++ b/src/data.go
@@ -83,6 +83,26 @@ func GetResources(file string, dirName string) ([]ResourceV2, error) {
 	return Resources, nil
 }
 
+// HasAWSDefaultTags reports whether any provider "aws" block in body declares
+// a default_tags block, which causes the provider to tag every taggable
+// resource even when the resource itself has no tags attribute.
+func HasAWSDefaultTags(body *hclsyntax.Body) bool {
+	if body == nil {
+		return false
+	}
+	for _, block := range body.Blocks {
+		if block.Type != "provider" || len(block.Labels) == 0 || !strings.EqualFold(block.Labels[0], "aws") {
+			continue
+		}
+		for _, inner := range block.Body.Blocks {
+			if inner.Type == "default_tags" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ExtractIAMBindings extracts IAM binding resources from parsed HCL blocks.
 func ExtractIAMBindings(body *hclsyntax.Body) []IAMBinding {
 	var bindings []IAMBinding

--- a/src/data_internal_test.go
+++ b/src/data_internal_test.go
@@ -3,8 +3,39 @@ package pike
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
 )
+
+func parseHCL(t *testing.T, src string) *hclsyntax.Body {
+	t.Helper()
+	f, diags := hclparse.NewParser().ParseHCL([]byte(src), "test.tf")
+	if diags.HasErrors() {
+		t.Fatalf("parse: %v", diags)
+	}
+	return f.Body.(*hclsyntax.Body)
+}
+
+func TestHasAWSDefaultTags(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"with default_tags", "provider \"aws\" {\n  default_tags {\n    tags = { env = \"prod\" }\n  }\n}\n", true},
+		{"aws no default_tags", "provider \"aws\" { region = \"eu-west-2\" }\n", false},
+		{"non-aws provider", "provider \"google\" {\n  default_tags {}\n}\n", false},
+		{"no provider", "resource \"aws_instance\" \"x\" {}\n", false},
+		{"mixed-case label", "provider \"AWS\" {\n  default_tags {}\n}\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasAWSDefaultTags(parseHCL(t, tt.src)))
+		})
+	}
+	assert.False(t, HasAWSDefaultTags(nil))
+}
 
 func Test_fileStringEmptyError_Error(t *testing.T) {
 	tests := []struct {

--- a/src/scan.go
+++ b/src/scan.go
@@ -229,6 +229,7 @@ func makePermissionBag(dirName string, file *string, init bool, provider string,
 	var criticalErrors []error
 
 	var allIAMBindings []IAMBinding
+	awsDefaultTags := false
 
 	for _, tfFile := range files {
 		resource, err := GetResources(tfFile, dirName)
@@ -247,7 +248,12 @@ func makePermissionBag(dirName string, file *string, init bool, provider string,
 		if err == nil && body != nil {
 			bindings := ExtractIAMBindings(body)
 			allIAMBindings = append(allIAMBindings, bindings...)
+			awsDefaultTags = awsDefaultTags || HasAWSDefaultTags(body)
 		}
+	}
+
+	if awsDefaultTags {
+		applyAWSDefaultTags(resources)
 	}
 
 	// Fail fast if too many critical files failed
@@ -262,6 +268,17 @@ func makePermissionBag(dirName string, file *string, init bool, provider string,
 	permissionsBag := GetPermissionBag(resources, provider, suppressDeprecated)
 	permissionsBag.IAMBindings = allIAMBindings
 	return permissionsBag, nil
+}
+
+// applyAWSDefaultTags injects a synthetic "tags" attribute into every AWS
+// resource so GetPermissionMap emits each mapping's attributes.tags actions.
+func applyAWSDefaultTags(resources []ResourceV2) {
+	for i := range resources {
+		if resources[i].Provider != provider.AWS || Contains(resources[i].Attributes, "tags") {
+			continue
+		}
+		resources[i].Attributes = append(resources[i].Attributes, "tags")
+	}
 }
 
 func GetPermissionBag(resources []ResourceV2, prov string, suppressDeprecated bool) Sorted {

--- a/src/scan_internal_test.go
+++ b/src/scan_internal_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_applyAWSDefaultTags(t *testing.T) {
+	resources := []ResourceV2{
+		{Provider: "aws", Name: "aws_instance", Attributes: []string{"ami"}},
+		{Provider: "aws", Name: "aws_vpc", Attributes: []string{"cidr_block", "tags"}},
+		{Provider: "google", Name: "google_compute_instance", Attributes: []string{"name"}},
+	}
+	applyAWSDefaultTags(resources)
+	assert.Contains(t, resources[0].Attributes, "tags")
+	assert.Equal(t, []string{"cidr_block", "tags"}, resources[1].Attributes)
+	assert.NotContains(t, resources[2].Attributes, "tags")
+}
+
 func Test_emptyIACError_Error(t *testing.T) {
 	tests := []struct {
 		name string

--- a/testdata/api_surface.txt
+++ b/testdata/api_surface.txt
@@ -44,6 +44,7 @@ func GetResources (file string, dirName string) ([]ResourceV2, error)
 func GetRuntimePermissions (raw []byte, attributes []string, resource string) ([]string, error)
 func GetTF (dirName string) ([]string, error)
 func GetTFFiles (dirName string) ([]string, error)
+func HasAWSDefaultTags (body *hclsyntax.Body) bool
 func Init (dirName string) (*string, []string, error)
 func Inspect (directory string, init bool) (PolicyDiff, error)
 func InvokeGithubDispatchEvent (repository string, workflowFileName string, branch string) error


### PR DESCRIPTION
When a provider "aws" block declares default_tags, the provider tags every taggable resource at apply time even if the resource block has no tags attribute. Detect this and inject a synthetic "tags" attribute into every AWS resource so each mapping's attributes.tags actions (e.g. ec2:CreateTags/DeleteTags) are included in the generated policy.

Closes #29