### PR TITLE
feat: add pike bootstrap - experimental AWS IAM deploy-role generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+internal/bootstrap/config/testdata/*.yaml eol=lf
+testdata/bootstrap/**/*.yaml eol=lf
+testdata/bootstrap/**/expected/*.json eol=lf

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        uses: github/codeql-action/init@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +61,7 @@ jobs:
       - name: Autobuild
         env:
           GOTOOLCHAIN: auto
-        uses: github/codeql-action/autobuild@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        uses: github/codeql-action/autobuild@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -74,4 +74,4 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        uses: github/codeql-action/analyze@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,6 +28,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        uses: github/codeql-action/upload-sarif@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 30

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Pike is a tool to determine the minimum IAM permissions required to run OpenTofu
 - JSON modules support.
 - GCP compare, checks IAC permissions required versus a deployed role.
 - Backend detection S3 and GCP.
+- `pike bootstrap` (**Experimental**, AWS-only): generates a permissions-boundary-constrained deploy role so a
+  Terraform deploy identity's IAM-management access can't be used to escalate to account admin. See
+  [Bootstrap (Experimental)](#bootstrap-experimental).
 
 Pike currently supports OpenTofu/Terraform and supports multiple providers (AWS, GCP and AZURE);
 Azure is the newest with AWS having the most supported resources
@@ -102,6 +105,7 @@ Get started with Pike in 3 steps:
     - [Watch](#watch)
     - [Parse](#parse)
   - [Compare](#compare)
+  - [Bootstrap (Experimental)](#bootstrap-experimental)
   - [Help](#help)
   - [Building](#building)
   - [Inspect](#inspect)
@@ -648,6 +652,40 @@ Pike always warns to stderr when the computed policy contains escalation-class p
 ```bash
 pike compare --strict -d ./terraform -a arn:aws:iam::680235478471:policy/terraform_pike
 ```
+
+## Bootstrap (Experimental)
+
+**This command is experimental and AWS-only.**
+
+Terraform/OpenTofu deploy identities usually need `iam:CreateRole`, `iam:PassRole` and similar IAM-management
+permissions to do their job. Combined, those are also the standard way an identity escalates itself to full account
+admin (create a role with broad permissions, pass it to something you can also provision, then run as that role).
+`pike bootstrap` generates a deploy-role setup that closes that specific escalation path: every role the deploy
+identity creates is forced to carry a permissions boundary it cannot remove or swap out, `iam:PassRole` is
+restricted to an explicit service allow-list, and the deploy role's own assumption requires MFA.
+
+```shell
+pike bootstrap -d ./path/to/your/terraform --config pike.yaml
+```
+
+This reads `pike.yaml` (see `internal/bootstrap/config/testdata/pike.yaml` for an example — the account ID,
+deploy-role path, MFA settings, and PassRole/service-linked-role allow-lists all live there), scans the
+directory the same way `pike scan` does, and writes six artifacts to `.pike/bootstrap/` (or wherever `pike.yaml`'s
+`output.directory` points):
+
+- `deploy-policy.json` — what Terraform actually requests, unrestricted.
+- `deploy-boundary.json` — the maximum permissions the deploy role may hold once bootstrapped: IAM/STS actions are
+  scoped, conditioned or denied per the rules above; every other action passes through unchanged.
+- `workload-boundary.json` — the permissions boundary attached to every role the deploy role creates.
+- `trust-policy.json` / `assume-role-policy.json` — the MFA-enforced trust relationship for the deploy role.
+- `report.json` — a summary of what was requested versus what was rewritten or denied, plus a hash of every
+  artifact.
+
+**What this does *not* give you: least privilege.** Non-IAM actions (S3, ECS, VPC, and so on) are still granted with
+`Resource: ["*"]`, for the same reason pike's other output is wildcard-resourced — generation is static analysis
+only and never queries live AWS state for real ARNs (see the CAVEAT at the top of this README). `pike bootstrap`
+only guarantees that the deploy role can't use its IAM-management access to escalate past the boundary you've
+configured; it does not scope down what that boundary itself allows for non-IAM services.
 
 ## Pull
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.290.0
 	gopkg.in/ini.v1 v1.67.3
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -96,7 +97,6 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,0 +1,201 @@
+// Package bootstrap wires the generate -> validate -> report pipeline
+// (config, classify, render, transform, validate, report) into a single
+// entry point the CLI's "bootstrap" command drives. This is the AWS-only,
+// EXPERIMENTAL IAM deploy-role bootstrap: it prevents a Terraform deploy
+// role's iam:CreateRole/PassRole access from being used to escalate to
+// account admin, but it is not a least-privilege policy generator - every
+// non-IAM action pike detects is still scoped to Resource ["*"], since
+// generation is static analysis only and never inspects live AWS state.
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/report"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/transform"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/validate"
+	"github.com/jameswoolfenden/pike/internal/scan"
+	pike "github.com/jameswoolfenden/pike/src"
+)
+
+// defaultOutputSubdir is where generated artifacts land under the scanned
+// directory when pike.yaml's output.directory is empty, alongside pike's
+// existing .pike output convention (pike.generated_policy.tf etc).
+const defaultOutputSubdir = ".pike/bootstrap"
+
+// artifactFilenames are the six files a generate run writes.
+var artifactFilenames = []string{
+	"deploy-policy.json",
+	"deploy-boundary.json",
+	"workload-boundary.json",
+	"trust-policy.json",
+	"assume-role-policy.json",
+	"report.json",
+}
+
+// Run scans directory for AWS IAM permissions, loads configPath (pike.yaml
+// by default), and generates the deploy-policy/deploy-boundary/workload-
+// boundary/trust-policy/assume-role-policy/report artifacts. Artifacts are
+// always written, even when validation produces blocking findings, so the
+// caller can inspect what's wrong - but Run returns a non-nil error in
+// that case (and CI callers should treat that as generation having
+// failed).
+func Run(directory, configPath string) error {
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", configPath, err)
+	}
+
+	cfg, err := config.Parse(configBytes)
+	if err != nil {
+		return fmt.Errorf("%s: %w", configPath, err)
+	}
+
+	var analyzer scan.PikeAnalyzer
+
+	p, err := analyzer.Scan(context.Background(), directory)
+	if err != nil {
+		return fmt.Errorf("scanning %s: %w", directory, err)
+	}
+
+	deployPolicy := render.DeployPolicy(p)
+
+	deployBoundary, err := transform.DeployBoundary(p, cfg)
+	if err != nil {
+		return fmt.Errorf("generating deploy boundary: %w", err)
+	}
+
+	workloadBoundary, err := render.WorkloadBoundary(cfg)
+	if err != nil {
+		return fmt.Errorf("generating workload boundary: %w", err)
+	}
+
+	trustPolicy, err := render.TrustPolicy(cfg)
+	if err != nil {
+		return fmt.Errorf("generating trust policy: %w", err)
+	}
+
+	assumeRolePolicy := render.AssumeRolePolicy(cfg)
+
+	findings := validate.Validate(validate.Artifacts{
+		DeployBoundary:   deployBoundary,
+		TrustPolicy:      trustPolicy,
+		AssumeRolePolicy: assumeRolePolicy,
+	}, cfg)
+
+	r, err := report.Generate(report.Input{
+		GeneratedAt:        time.Now().UTC(),
+		GeneratorVersion:   pike.Version,
+		ScannerName:        "pike",
+		MappingRevision:    pike.Version,
+		TerraformDirectory: directory,
+		ConfigBytes:        configBytes,
+		DeployPolicy:       deployPolicy,
+		DeployBoundary:     deployBoundary,
+		WorkloadBoundary:   workloadBoundary,
+		Findings:           findings,
+	})
+	if err != nil {
+		return fmt.Errorf("generating report: %w", err)
+	}
+
+	outputDir, err := resolveOutputDir(directory, cfg)
+	if err != nil {
+		return err
+	}
+
+	if !cfg.Output.Overwrite {
+		if err := refuseIfArtifactsExist(outputDir); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		return fmt.Errorf("creating %s: %w", outputDir, err)
+	}
+
+	artifacts := map[string]any{
+		"deploy-policy.json":      deployPolicy,
+		"deploy-boundary.json":    deployBoundary,
+		"workload-boundary.json":  workloadBoundary,
+		"trust-policy.json":       trustPolicy,
+		"assume-role-policy.json": assumeRolePolicy,
+		"report.json":             r,
+	}
+
+	for _, name := range artifactFilenames {
+		if err := writeJSON(filepath.Join(outputDir, name), artifacts[name]); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("pike bootstrap: wrote %d artifacts to %s\n", len(artifactFilenames), outputDir)
+
+	var blocking int
+
+	for _, f := range findings {
+		if f.Severity == validate.Blocking {
+			blocking++
+
+			fmt.Printf("  BLOCKING [%s] %s\n", f.Code, f.Message)
+		}
+	}
+
+	if blocking > 0 {
+		return fmt.Errorf("%d blocking validation finding(s), see %s", blocking, filepath.Join(outputDir, "report.json"))
+	}
+
+	return nil
+}
+
+// resolveOutputDir honors pike.yaml's output.directory when set (relative
+// paths are resolved against the scanned directory, matching how
+// directory-scoped output already works elsewhere in pike), defaulting to
+// defaultOutputSubdir otherwise.
+func resolveOutputDir(directory string, cfg *config.Config) (string, error) {
+	if cfg.Output.Directory == "" {
+		return filepath.Join(directory, defaultOutputSubdir), nil
+	}
+
+	if filepath.IsAbs(cfg.Output.Directory) {
+		return cfg.Output.Directory, nil
+	}
+
+	return filepath.Join(directory, cfg.Output.Directory), nil
+}
+
+// refuseIfArtifactsExist protects existing artifacts from a silent
+// overwrite when output.overwrite is false (the config default) - the
+// caller must opt in before a re-run replaces prior output.
+func refuseIfArtifactsExist(outputDir string) error {
+	for _, name := range artifactFilenames {
+		path := filepath.Join(outputDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("%s already exists and output.overwrite is false", path)
+		}
+	}
+
+	return nil
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", path, err)
+	}
+
+	b = append(b, '\n')
+
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/internal/bootstrap/classify/classify.go
+++ b/internal/bootstrap/classify/classify.go
@@ -1,0 +1,126 @@
+// Package classify implements Pike's IAM/STS action security
+// classification (spec section 10). Every IAM or STS action a deploy
+// policy requests gets classified here so deploy-boundary transformation
+// knows how to treat it — preserve, scope to the managed-role path,
+// explicitly deny, or fail closed. Actions for other services (ec2,
+// ecs, ...) never go through this classifier; boundary transformation
+// preserves those unchanged.
+package classify
+
+import "strings"
+
+// Class is the security classification of a single IAM or STS action.
+type Class string
+
+const (
+	Read              Class = "read"
+	RoleCreate        Class = "role-create"
+	RolePolicyWrite   Class = "role-policy-write"
+	PassRole          Class = "pass-role"
+	ServiceLinkedRole Class = "service-linked-role"
+	BoundaryMutation  Class = "boundary-mutation"
+	PolicyMutation    Class = "policy-mutation"
+	HumanPrincipal    Class = "human-principal"
+	Organization      Class = "organization"
+	Unknown           Class = "unknown"
+)
+
+// exact classifies actions that don't fit a general verb-prefix rule, or
+// that would otherwise be misclassified by one (e.g. iam:DeleteRole reads
+// like a generic write but must be grouped with the managed-role-path
+// writes in section 12.2, not left to fall through to Unknown).
+var exact = map[string]Class{
+	"iam:CreateRole": RoleCreate,
+
+	// section 12.2 ManageTerraformRoles: the exact write actions the
+	// deploy role gets, scoped to the managed-role path.
+	"iam:AttachRolePolicy":           RolePolicyWrite,
+	"iam:DeleteRole":                 RolePolicyWrite,
+	"iam:DeleteRolePolicy":           RolePolicyWrite,
+	"iam:DetachRolePolicy":           RolePolicyWrite,
+	"iam:PutRolePolicy":              RolePolicyWrite,
+	"iam:PutRolePermissionsBoundary": RolePolicyWrite,
+	"iam:TagRole":                    RolePolicyWrite,
+	"iam:UntagRole":                  RolePolicyWrite,
+
+	"iam:PassRole": PassRole,
+
+	"iam:CreateServiceLinkedRole": ServiceLinkedRole,
+
+	// section 12.5 DenyWorkloadBoundaryRemoval.
+	"iam:DeleteRolePermissionsBoundary": BoundaryMutation,
+
+	// section 12.5 DenyBoundaryPolicyMutation.
+	"iam:CreatePolicyVersion":     PolicyMutation,
+	"iam:DeletePolicyVersion":     PolicyMutation,
+	"iam:SetDefaultPolicyVersion": PolicyMutation,
+	"iam:DeletePolicy":            PolicyMutation,
+
+	// Human-identity and access-key management (section 10 groups both
+	// under the single human-principal class).
+	"iam:CreateUser":             HumanPrincipal,
+	"iam:DeleteUser":             HumanPrincipal,
+	"iam:UpdateUser":             HumanPrincipal,
+	"iam:CreateLoginProfile":     HumanPrincipal,
+	"iam:UpdateLoginProfile":     HumanPrincipal,
+	"iam:DeleteLoginProfile":     HumanPrincipal,
+	"iam:CreateAccessKey":        HumanPrincipal,
+	"iam:UpdateAccessKey":        HumanPrincipal,
+	"iam:DeleteAccessKey":        HumanPrincipal,
+	"iam:CreateVirtualMFADevice": HumanPrincipal,
+	"iam:DeactivateMFADevice":    HumanPrincipal,
+	"iam:DeleteVirtualMFADevice": HumanPrincipal,
+	"iam:EnableMFADevice":        HumanPrincipal,
+	"iam:ResyncMFADevice":        HumanPrincipal,
+}
+
+// readVerbPrefixes are the AWS API verb conventions for read-only calls,
+// applied across both iam: and sts: actions.
+var readVerbPrefixes = []string{"Get", "List", "Generate", "Describe"}
+
+// Classify returns the security classification for an IAM or STS action
+// (e.g. "iam:CreateRole", "sts:GetCallerIdentity"). Unrecognised IAM/STS
+// writes return Unknown so callers fail closed (section 4.2 rule 7)
+// instead of silently allowing an action nobody has reasoned about.
+func Classify(action string) Class {
+	if class, ok := exact[action]; ok {
+		return class
+	}
+
+	service, verb, ok := split(action)
+	if !ok {
+		return Unknown
+	}
+
+	// Organizations/account governance is denied outright regardless of
+	// read or write (section 12.5), so it's checked before the read rule
+	// and before the iam/sts scope restriction below.
+	if service == "organizations" || service == "account" {
+		return Organization
+	}
+
+	// The read-verb rule only applies within this classifier's actual
+	// scope (IAM/STS). Without this, a non-IAM action that happens to
+	// start with a read verb (e.g. "ec2:DescribeInstances") would be
+	// mislabeled Read instead of Unknown.
+	if service != "iam" && service != "sts" {
+		return Unknown
+	}
+
+	for _, prefix := range readVerbPrefixes {
+		if strings.HasPrefix(verb, prefix) {
+			return Read
+		}
+	}
+
+	return Unknown
+}
+
+func split(action string) (service, verb string, ok bool) {
+	i := strings.IndexByte(action, ':')
+	if i < 0 {
+		return "", "", false
+	}
+
+	return action[:i], action[i+1:], true
+}

--- a/internal/bootstrap/classify/classify_test.go
+++ b/internal/bootstrap/classify/classify_test.go
@@ -1,0 +1,79 @@
+package classify_test
+
+import (
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/classify"
+)
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		action string
+		want   classify.Class
+	}{
+		// section 10 table examples, verbatim.
+		{"iam:GetRole", classify.Read},
+		{"iam:ListRolePolicies", classify.Read},
+		{"iam:CreateRole", classify.RoleCreate},
+		{"iam:PutRolePolicy", classify.RolePolicyWrite},
+		{"iam:AttachRolePolicy", classify.RolePolicyWrite},
+		{"iam:PassRole", classify.PassRole},
+		{"iam:CreateServiceLinkedRole", classify.ServiceLinkedRole},
+		{"iam:DeleteRolePermissionsBoundary", classify.BoundaryMutation},
+		{"iam:CreatePolicyVersion", classify.PolicyMutation},
+		{"iam:CreateUser", classify.HumanPrincipal},
+		{"iam:CreateAccessKey", classify.HumanPrincipal},
+
+		// section 12.2 ManageTerraformRoles: every action in that
+		// statement must land in role-policy-write.
+		{"iam:DeleteRole", classify.RolePolicyWrite},
+		{"iam:DeleteRolePolicy", classify.RolePolicyWrite},
+		{"iam:DetachRolePolicy", classify.RolePolicyWrite},
+		{"iam:PutRolePermissionsBoundary", classify.RolePolicyWrite},
+		{"iam:TagRole", classify.RolePolicyWrite},
+		{"iam:UntagRole", classify.RolePolicyWrite},
+
+		// section 12.5 DenyBoundaryPolicyMutation: every action in that
+		// statement must land in policy-mutation.
+		{"iam:DeletePolicyVersion", classify.PolicyMutation},
+		{"iam:SetDefaultPolicyVersion", classify.PolicyMutation},
+		{"iam:DeletePolicy", classify.PolicyMutation},
+
+		// organizations:*, account:* (section 7.1 / 10) — denied
+		// regardless of whether the specific action is a read or a write.
+		{"organizations:DescribeOrganization", classify.Organization},
+		{"organizations:LeaveOrganization", classify.Organization},
+		{"account:GetAccountInformation", classify.Organization},
+		{"account:EnableRegion", classify.Organization},
+
+		// generic read-verb rule applies across services, not just iam.
+		{"sts:GetCallerIdentity", classify.Read},
+		{"iam:ListAttachedRolePolicies", classify.Read},
+		{"iam:GenerateCredentialReport", classify.Read},
+		{"iam:GetAccountSummary", classify.Read},
+
+		// unmapped IAM/STS writes fail closed.
+		{"iam:TagPolicy", classify.Unknown},
+		{"sts:AssumeRole", classify.Unknown},
+		{"iam:UpdateRoleDescription", classify.Unknown},
+
+		// malformed / non-IAM actions: out of this classifier's scope,
+		// so also Unknown rather than guessed at.
+		{"ec2:DescribeInstances", classify.Unknown},
+		{"no-colon-here", classify.Unknown},
+		{"", classify.Unknown},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.action, func(t *testing.T) {
+			t.Parallel()
+
+			if got := classify.Classify(tt.action); got != tt.want {
+				t.Errorf("Classify(%q) = %q, want %q", tt.action, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/bootstrap/config/config.go
+++ b/internal/bootstrap/config/config.go
@@ -1,0 +1,237 @@
+// Package config parses and validates pike.yaml, the bootstrap
+// configuration file describing the AWS account, source principal,
+// deploy role and boundary policies Pike generates IAM artifacts for.
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const SupportedVersion = 1
+
+var accountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
+
+// Config is the root of pike.yaml.
+type Config struct {
+	Version            int                      `yaml:"version"`
+	AWS                AWSConfig                `yaml:"aws"`
+	Principal          PrincipalConfig          `yaml:"principal"`
+	DeployRole         DeployRoleConfig         `yaml:"deploy_role"`
+	ManagedRoles       ManagedRolesConfig       `yaml:"managed_roles"`
+	Policies           PoliciesConfig           `yaml:"policies"`
+	PassRole           PassRoleConfig           `yaml:"pass_role"`
+	ServiceLinkedRoles ServiceLinkedRolesConfig `yaml:"service_linked_roles"`
+	Security           SecurityConfig           `yaml:"security"`
+	Output             OutputConfig             `yaml:"output"`
+}
+
+type AWSConfig struct {
+	AccountID string `yaml:"account_id"`
+	Partition string `yaml:"partition"`
+	Region    string `yaml:"region"`
+}
+
+type MFAConfig struct {
+	Required      bool   `yaml:"required"`
+	Serial        string `yaml:"serial"`
+	MaxAgeSeconds int    `yaml:"max_age_seconds"`
+}
+
+type PrincipalConfig struct {
+	Type string    `yaml:"type"`
+	Name string    `yaml:"name"`
+	MFA  MFAConfig `yaml:"mfa"`
+}
+
+type DeployRoleConfig struct {
+	Name               string `yaml:"name"`
+	Path               string `yaml:"path"`
+	MaxSessionDuration int    `yaml:"max_session_duration"`
+}
+
+type ManagedRolesConfig struct {
+	Path string `yaml:"path"`
+}
+
+// PolicyConfig identifies a single managed policy by name and IAM path.
+type PolicyConfig struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
+}
+
+// WorkloadBoundaryConfig is a PolicyConfig plus the explicit allowlist
+// mode described in spec section 13 (the workload boundary is generated
+// from configuration, never inferred from the deploy policy).
+type WorkloadBoundaryConfig struct {
+	Name           string   `yaml:"name"`
+	Path           string   `yaml:"path"`
+	Mode           string   `yaml:"mode"`
+	AllowedActions []string `yaml:"allowed_actions"`
+}
+
+type PoliciesConfig struct {
+	Deploy           PolicyConfig           `yaml:"deploy"`
+	DeployBoundary   PolicyConfig           `yaml:"deploy_boundary"`
+	WorkloadBoundary WorkloadBoundaryConfig `yaml:"workload_boundary"`
+}
+
+type PassRoleConfig struct {
+	AllowedServices []string `yaml:"allowed_services"`
+}
+
+type ServiceLinkedRolesConfig struct {
+	AllowedServices []string `yaml:"allowed_services"`
+}
+
+type SecurityConfig struct {
+	FailOnUnknownIAMAction       bool `yaml:"fail_on_unknown_iam_action"`
+	DenyBoundaryRemoval          bool `yaml:"deny_boundary_removal"`
+	DenyBoundaryPolicyMutation   bool `yaml:"deny_boundary_policy_mutation"`
+	DenyHumanPrincipalManagement bool `yaml:"deny_human_principal_management"`
+	DenyAccessKeyManagement      bool `yaml:"deny_access_key_management"`
+	DenyOrganizationManagement   bool `yaml:"deny_organization_management"`
+}
+
+type OutputConfig struct {
+	Directory string `yaml:"directory"`
+	Overwrite bool   `yaml:"overwrite"`
+}
+
+// workloadAllowlistDenylist is the set of actions/wildcards spec section
+// 7.1 forbids in policies.workload_boundary.allowed_actions, since any of
+// them would let a Terraform-created workload role manage or escalate IAM
+// itself.
+var workloadAllowlistDenylist = []string{"*", "iam:*", "sts:*", "organizations:*", "account:*"}
+
+// Load reads and validates a pike.yaml file at path. Unknown fields are
+// rejected, and IAM paths are normalized (leading and trailing "/") before
+// validation runs.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	cfg, err := Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	return cfg, nil
+}
+
+// Parse decodes and validates pike.yaml content already read into memory.
+func Parse(data []byte) (*Config, error) {
+	var cfg Config
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	cfg.normalize()
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// normalize rewrites every configured IAM path to have both a leading and
+// trailing "/", so downstream ARN construction never has to special-case
+// missing slashes. An empty or root path normalizes to "/".
+func (c *Config) normalize() {
+	c.DeployRole.Path = normalizeIAMPath(c.DeployRole.Path)
+	c.ManagedRoles.Path = normalizeIAMPath(c.ManagedRoles.Path)
+	c.Policies.Deploy.Path = normalizeIAMPath(c.Policies.Deploy.Path)
+	c.Policies.DeployBoundary.Path = normalizeIAMPath(c.Policies.DeployBoundary.Path)
+	c.Policies.WorkloadBoundary.Path = normalizeIAMPath(c.Policies.WorkloadBoundary.Path)
+}
+
+func normalizeIAMPath(p string) string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return "/"
+	}
+
+	return "/" + trimmed + "/"
+}
+
+// Validate checks the self-contained rules from spec section 7.1 — the
+// ones decidable from pike.yaml alone. Rules that depend on the
+// Terraform scan result (PassRole/CreateServiceLinkedRole services being
+// configured when those actions are actually detected) belong to the
+// transform/validate stage, once a scanned Policy is available to check
+// against.
+func (c *Config) Validate() error {
+	if c.Version != SupportedVersion {
+		return fmt.Errorf("unsupported config version %d (supported: %d)", c.Version, SupportedVersion)
+	}
+
+	if !accountIDPattern.MatchString(c.AWS.AccountID) {
+		return fmt.Errorf("aws.account_id must be exactly 12 decimal digits, got %q", c.AWS.AccountID)
+	}
+
+	if c.ManagedRoles.Path == "/" {
+		return fmt.Errorf("managed_roles.path must not be \"/\"")
+	}
+
+	if c.Principal.MFA.Required && c.Principal.MFA.Serial == "" {
+		return fmt.Errorf("principal.mfa.serial is required when principal.mfa.required is true")
+	}
+
+	if err := c.validateDistinctPaths(); err != nil {
+		return err
+	}
+
+	if err := c.validateWorkloadAllowlist(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateDistinctPaths enforces "deploy, managed-role and boundary policy
+// paths must be distinct" (section 7.1). The reference config in section 7
+// deliberately gives deploy_boundary and workload_boundary the *same* path
+// ("/boundaries/"), so that pair is not required to differ from each
+// other — only the deploy-role path and the managed-role path must each
+// stay clear of the other two categories and of each other.
+func (c *Config) validateDistinctPaths() error {
+	if c.DeployRole.Path == c.ManagedRoles.Path {
+		return fmt.Errorf("deploy_role.path and managed_roles.path must be distinct, both are %q", c.DeployRole.Path)
+	}
+
+	for _, boundaryPath := range []string{c.Policies.DeployBoundary.Path, c.Policies.WorkloadBoundary.Path} {
+		if c.DeployRole.Path == boundaryPath {
+			return fmt.Errorf("deploy_role.path must not equal a boundary policy path (%q)", boundaryPath)
+		}
+
+		if c.ManagedRoles.Path == boundaryPath {
+			return fmt.Errorf("managed_roles.path must not equal a boundary policy path (%q)", boundaryPath)
+		}
+	}
+
+	return nil
+}
+
+func (c *Config) validateWorkloadAllowlist() error {
+	for _, action := range c.Policies.WorkloadBoundary.AllowedActions {
+		for _, denied := range workloadAllowlistDenylist {
+			if action == denied {
+				return fmt.Errorf("policies.workload_boundary.allowed_actions must not contain %q", action)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/bootstrap/config/config_test.go
+++ b/internal/bootstrap/config/config_test.go
@@ -1,0 +1,259 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+)
+
+func TestLoad_ValidExample(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.Load("testdata/pike.yaml")
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if cfg.AWS.AccountID != "123456789012" {
+		t.Errorf("AWS.AccountID = %q, want %q", cfg.AWS.AccountID, "123456789012")
+	}
+
+	if cfg.DeployRole.Name != "TerraformDeployRole" {
+		t.Errorf("DeployRole.Name = %q, want %q", cfg.DeployRole.Name, "TerraformDeployRole")
+	}
+
+	if len(cfg.Policies.WorkloadBoundary.AllowedActions) != 8 {
+		t.Errorf("len(Policies.WorkloadBoundary.AllowedActions) = %d, want 8", len(cfg.Policies.WorkloadBoundary.AllowedActions))
+	}
+}
+
+func TestParse_PathNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"already normalized", "/terraform-deploy/", "/terraform-deploy/"},
+		{"missing both slashes", "terraform-deploy", "/terraform-deploy/"},
+		{"missing leading slash", "terraform-deploy/", "/terraform-deploy/"},
+		{"missing trailing slash", "/terraform-deploy", "/terraform-deploy/"},
+		{"empty defaults to root", "", "/"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := validYAML(func(y *yamlOverrides) {
+				y.deployRolePath = tt.input
+			})
+
+			cfg, err := config.Parse([]byte(data))
+			if err != nil {
+				t.Fatalf("Parse() error = %v, want nil", err)
+			}
+
+			if cfg.DeployRole.Path != tt.want {
+				t.Errorf("DeployRole.Path = %q, want %q", cfg.DeployRole.Path, tt.want)
+			}
+		})
+	}
+}
+
+func TestParse_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+
+	data := strings.Replace(baseYAML, "version: 1", "version: 1\nbogus_field: true", 1)
+
+	if _, err := config.Parse([]byte(data)); err == nil {
+		t.Fatal("Parse() error = nil, want error for unknown field")
+	}
+}
+
+func TestValidate_Rules(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*yamlOverrides)
+		wantErr string
+	}{
+		{
+			name:    "unsupported version",
+			mutate:  func(y *yamlOverrides) { y.version = "2" },
+			wantErr: "unsupported config version",
+		},
+		{
+			name:    "account id too short",
+			mutate:  func(y *yamlOverrides) { y.accountID = "12345" },
+			wantErr: "12 decimal digits",
+		},
+		{
+			name:    "account id non-numeric",
+			mutate:  func(y *yamlOverrides) { y.accountID = "12345678901a" },
+			wantErr: "12 decimal digits",
+		},
+		{
+			name:    "managed roles path is root",
+			mutate:  func(y *yamlOverrides) { y.managedRolesPath = "/" },
+			wantErr: `managed_roles.path must not be "/"`,
+		},
+		{
+			name:    "mfa required without serial",
+			mutate:  func(y *yamlOverrides) { y.mfaSerial = "" },
+			wantErr: "principal.mfa.serial is required",
+		},
+		{
+			name:    "deploy role path equals managed roles path",
+			mutate:  func(y *yamlOverrides) { y.deployRolePath = "/terraform-managed/" },
+			wantErr: "must be distinct",
+		},
+		{
+			name:    "deploy role path equals boundary path",
+			mutate:  func(y *yamlOverrides) { y.deployRolePath = "/boundaries/" },
+			wantErr: "must not equal a boundary policy path",
+		},
+		{
+			name:    "managed roles path equals boundary path",
+			mutate:  func(y *yamlOverrides) { y.managedRolesPath = "/boundaries/" },
+			wantErr: "must not equal a boundary policy path",
+		},
+		{
+			name:    "workload allowlist contains wildcard",
+			mutate:  func(y *yamlOverrides) { y.workloadAction = "*" },
+			wantErr: "must not contain",
+		},
+		{
+			name:    "workload allowlist contains iam wildcard",
+			mutate:  func(y *yamlOverrides) { y.workloadAction = "iam:*" },
+			wantErr: "must not contain",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := validYAML(tt.mutate)
+
+			_, err := config.Parse([]byte(data))
+			if err == nil {
+				t.Fatalf("Parse() error = nil, want error containing %q", tt.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Parse() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidate_DeployBoundaryAndWorkloadBoundarySharingAPathIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	// The reference example intentionally gives deploy_boundary and
+	// workload_boundary the same path; only the deploy-role and
+	// managed-role paths must stay clear of it.
+	if _, err := config.Parse([]byte(baseYAML)); err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+}
+
+// yamlOverrides lets each Validate test mutate exactly one field of an
+// otherwise-valid config, so a failure can be attributed to that field.
+type yamlOverrides struct {
+	version          string
+	accountID        string
+	deployRolePath   string
+	managedRolesPath string
+	mfaSerial        string
+	workloadAction   string
+}
+
+const baseYAML = `version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: ap-northeast-2
+
+principal:
+  type: iam-user
+  name: cli-user
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/cli-user
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - logs:PutLogEvents
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  fail_on_unknown_iam_action: true
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false
+`
+
+// validYAML applies zero or more field overrides on top of baseYAML via
+// targeted string substitution, so each Validate test case only has to
+// name the one field it wants to change.
+func validYAML(mutate func(*yamlOverrides)) string {
+	y := &yamlOverrides{
+		version:          "1",
+		accountID:        "123456789012",
+		deployRolePath:   "/terraform-deploy/",
+		managedRolesPath: "/terraform-managed/",
+		mfaSerial:        "arn:aws:iam::123456789012:mfa/cli-user",
+		workloadAction:   "logs:PutLogEvents",
+	}
+	mutate(y)
+
+	data := baseYAML
+	data = strings.Replace(data, "version: 1", "version: "+y.version, 1)
+	data = strings.Replace(data, `account_id: "123456789012"`, `account_id: "`+y.accountID+`"`, 1)
+	data = strings.Replace(data, "path: /terraform-deploy/\n  max_session_duration", "path: "+y.deployRolePath+"\n  max_session_duration", 1)
+	data = strings.Replace(data, "managed_roles:\n  path: /terraform-managed/", "managed_roles:\n  path: "+y.managedRolesPath, 1)
+	data = strings.Replace(data, "serial: arn:aws:iam::123456789012:mfa/cli-user", "serial: "+y.mfaSerial, 1)
+	data = strings.Replace(data, "- logs:PutLogEvents", `- "`+y.workloadAction+`"`, 1)
+
+	return data
+}

--- a/internal/bootstrap/config/testdata/pike.yaml
+++ b/internal/bootstrap/config/testdata/pike.yaml
@@ -1,0 +1,66 @@
+version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: ap-northeast-2
+
+principal:
+  type: iam-user
+  name: me@qj0r9j0vc2.me-cli
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/me@qj0r9j0vc2.me-cli
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - ecr:GetAuthorizationToken
+      - ecr:BatchCheckLayerAvailability
+      - ecr:GetDownloadUrlForLayer
+      - ecr:BatchGetImage
+      - logs:CreateLogStream
+      - logs:PutLogEvents
+      - secretsmanager:GetSecretValue
+      - kms:Decrypt
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+    - scheduler.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  fail_on_unknown_iam_action: true
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false

--- a/internal/bootstrap/config/testdata/pike.yaml
+++ b/internal/bootstrap/config/testdata/pike.yaml
@@ -7,10 +7,10 @@ aws:
 
 principal:
   type: iam-user
-  name: me@qj0r9j0vc2.me-cli
+  name: cli-user
   mfa:
     required: true
-    serial: arn:aws:iam::123456789012:mfa/me@qj0r9j0vc2.me-cli
+    serial: arn:aws:iam::123456789012:mfa/cli-user
     max_age_seconds: 3600
 
 deploy_role:

--- a/internal/bootstrap/golden_test.go
+++ b/internal/bootstrap/golden_test.go
@@ -1,0 +1,182 @@
+// Package bootstrap_test holds end-to-end golden-fixture tests that
+// exercise the full generate pipeline (scan -> render deploy-policy ->
+// transform deploy-boundary -> render workload-boundary/trust-policy/
+// assume-role-policy -> validate -> report) against realistic input, spec
+// section 21.3.
+package bootstrap_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/report"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/transform"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/validate"
+	"github.com/jameswoolfenden/pike/internal/policy"
+	"github.com/jameswoolfenden/pike/internal/scan"
+)
+
+// goldenTime is the fixed GeneratedAt every fixture's report.json was
+// captured with, so report generation stays comparable across runs.
+var goldenTime = time.Date(2026, 7, 30, 0, 0, 0, 0, time.UTC)
+
+// syntheticPolicies holds the scan input for fixtures with no terraform/
+// directory — see each fixture's README.md for why a hand-built Policy
+// was used instead of a scanned one.
+var syntheticPolicies = map[string]policy.Policy{
+	"unknown-iam-action": {Statements: []policy.Statement{{Actions: []string{"iam:UpdateAssumeRolePolicy"}, Resources: []string{"*"}}}},
+	"managed-policy":     {Statements: []policy.Statement{{Actions: []string{"iam:CreatePolicyVersion"}, Resources: []string{"*"}}}},
+}
+
+func TestGolden(t *testing.T) {
+	fixtures := []string{
+		"no-iam",
+		"ecs-task-role",
+		"service-linked-role",
+		"managed-policy",
+		"unknown-iam-action",
+	}
+
+	for _, name := range fixtures {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runGoldenFixture(t, name)
+		})
+	}
+}
+
+func runGoldenFixture(t *testing.T, name string) {
+	t.Helper()
+
+	dir := filepath.Join("..", "..", "testdata", "bootstrap", name)
+
+	configBytes, err := os.ReadFile(filepath.Join(dir, "pike.yaml"))
+	if err != nil {
+		t.Fatalf("reading pike.yaml: %v", err)
+	}
+
+	cfg, err := config.Load(filepath.Join(dir, "pike.yaml"))
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+
+	p, ok := syntheticPolicies[name]
+	if !ok {
+		var a scan.PikeAnalyzer
+
+		p, err = a.Scan(context.Background(), filepath.Join(dir, "terraform"))
+		if err != nil {
+			t.Fatalf("Scan() error = %v", err)
+		}
+	}
+
+	deployPolicy := render.DeployPolicy(p)
+	assertGoldenJSON(t, filepath.Join(dir, "expected", "deploy-policy.json"), deployPolicy)
+
+	deployBoundary, err := transform.DeployBoundary(p, cfg)
+	if name == "unknown-iam-action" {
+		var target *transform.UnknownIAMActionError
+		if !errors.As(err, &target) {
+			t.Fatalf("DeployBoundary() error = %v, want *UnknownIAMActionError (this fixture only has an expected deploy-policy.json — see its README.md)", err)
+		}
+
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	assertGoldenJSON(t, filepath.Join(dir, "expected", "deploy-boundary.json"), deployBoundary)
+
+	workloadBoundary, err := render.WorkloadBoundary(cfg)
+	if err != nil {
+		t.Fatalf("WorkloadBoundary() error = %v", err)
+	}
+
+	assertGoldenJSON(t, filepath.Join(dir, "expected", "workload-boundary.json"), workloadBoundary)
+
+	trustPolicy, err := render.TrustPolicy(cfg)
+	if err != nil {
+		t.Fatalf("TrustPolicy() error = %v", err)
+	}
+
+	assertGoldenJSON(t, filepath.Join(dir, "expected", "trust-policy.json"), trustPolicy)
+
+	assumeRolePolicy := render.AssumeRolePolicy(cfg)
+	assertGoldenJSON(t, filepath.Join(dir, "expected", "assume-role-policy.json"), assumeRolePolicy)
+
+	findings := validate.Validate(validate.Artifacts{
+		DeployBoundary:   deployBoundary,
+		TrustPolicy:      trustPolicy,
+		AssumeRolePolicy: assumeRolePolicy,
+	}, cfg)
+
+	for _, f := range findings {
+		if f.Severity == validate.Blocking {
+			t.Errorf("unexpected blocking finding on a golden fixture: %+v", f)
+		}
+	}
+
+	r, err := report.Generate(report.Input{
+		GeneratedAt:        goldenTime,
+		GeneratorVersion:   "0.1.0",
+		ScannerName:        "pike",
+		MappingRevision:    "test",
+		TerraformDirectory: "./terraform",
+		ConfigBytes:        configBytes,
+		DeployPolicy:       deployPolicy,
+		DeployBoundary:     deployBoundary,
+		WorkloadBoundary:   workloadBoundary,
+		Findings:           findings,
+	})
+	if err != nil {
+		t.Fatalf("report.Generate() error = %v", err)
+	}
+
+	assertGoldenJSON(t, filepath.Join(dir, "expected", "report.json"), r)
+}
+
+// assertGoldenJSON compares got against the JSON file at path, both
+// normalized through json.Unmarshal into `any` first so formatting
+// differences (whitespace, key order in the source file) don't cause
+// false failures — only structural differences do.
+func assertGoldenJSON(t *testing.T, path string, got any) {
+	t.Helper()
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading golden file %s: %v", path, err)
+	}
+
+	gotBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshaling actual output for %s: %v", path, err)
+	}
+
+	var wantNormalized, gotNormalized any
+
+	if err := json.Unmarshal(want, &wantNormalized); err != nil {
+		t.Fatalf("parsing golden file %s: %v", path, err)
+	}
+
+	if err := json.Unmarshal(gotBytes, &gotNormalized); err != nil {
+		t.Fatalf("parsing actual output for %s: %v", path, err)
+	}
+
+	wantCanonical, _ := json.Marshal(wantNormalized)
+	gotCanonical, _ := json.Marshal(gotNormalized)
+
+	if string(gotCanonical) != string(wantCanonical) {
+		gotPretty, _ := json.MarshalIndent(gotNormalized, "", "  ")
+		t.Errorf("%s mismatch.\ngot:\n%s\n\nwant (golden file):\n%s", path, gotPretty, want)
+	}
+}

--- a/internal/bootstrap/render/deploy_policy.go
+++ b/internal/bootstrap/render/deploy_policy.go
@@ -1,0 +1,149 @@
+// Package render converts Pike's internal Policy model into the JSON
+// artifacts Pike writes to disk (spec section 8), starting with
+// deploy-policy.json (section 11).
+package render
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/classify"
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+// policyVersion is the fixed AWS IAM policy language version.
+const policyVersion = "2012-10-17"
+
+// Document is a rendered AWS IAM policy document.
+type Document struct {
+	Version    string      `json:"Version"`
+	Statements []Statement `json:"Statement"`
+}
+
+// Statement is a single Allow/Deny block within a Document.
+type Statement struct {
+	Sid       string     `json:"Sid"`
+	Effect    string     `json:"Effect"`
+	Action    []string   `json:"Action"`
+	Resource  []string   `json:"Resource"`
+	Condition *Condition `json:"Condition,omitempty"`
+}
+
+// Condition is an IAM policy condition block. Only StringEquals is
+// needed for the conditions Pike generates today: CreateRole's
+// PermissionsBoundary check and the PassRole/CreateServiceLinkedRole
+// service allowlists (spec section 12). Values are either a single
+// string or a string list; encoding/json sorts map keys automatically,
+// so this stays canonical (section 8.1) without extra work.
+type Condition struct {
+	StringEquals map[string]any `json:"StringEquals,omitempty"`
+}
+
+// DeployPolicy renders deploy-policy.json: the permissions Terraform
+// requests, preserved as scanned (spec section 11). It does not apply any
+// security restriction — that's deploy-boundary.json's job, kept in a
+// separate stage so the two artifacts stay independently reviewable
+// ("Deploy policy = what Terraform requests, Deploy boundary = maximum
+// safe delegation").
+//
+// Output is canonical (spec section 8.1): actions and resources within
+// each statement are sorted, and statements are ordered by their first
+// action, so identical scan input always renders identical bytes
+// regardless of any nondeterminism upstream in how Policy was built.
+func DeployPolicy(p policy.Policy) Document {
+	statements := make([]Statement, 0, len(p.Statements))
+
+	for i, s := range p.Statements {
+		actions := sortedUnique(s.Actions)
+		if len(actions) == 0 {
+			continue
+		}
+
+		statements = append(statements, Statement{
+			Sid:      "DeployPolicy" + strconv.Itoa(i),
+			Effect:   "Allow",
+			Action:   actions,
+			Resource: sortedUnique(s.Resources),
+		})
+	}
+
+	sort.Slice(statements, func(i, j int) bool {
+		return firstAction(statements[i]) < firstAction(statements[j])
+	})
+
+	for i := range statements {
+		statements[i].Sid = "DeployPolicy" + strconv.Itoa(i)
+	}
+
+	return Document{Version: policyVersion, Statements: statements}
+}
+
+// EscalationActions returns the deduplicated, sorted set of IAM/STS
+// actions in p that are not plain reads — every action spec section 3
+// calls an "escalation action" (one that can grant, pass, mutate or
+// indirectly obtain additional privileges). Section 11 requires these be
+// recorded in report.json; this is what that stage will read from.
+func EscalationActions(p policy.Policy) []string {
+	seen := make(map[string]bool)
+
+	var found []string
+
+	for _, action := range p.Actions() {
+		if !isIAMOrSTS(action) {
+			continue
+		}
+
+		if classify.Classify(action) == classify.Read {
+			continue
+		}
+
+		if seen[action] {
+			continue
+		}
+
+		seen[action] = true
+
+		found = append(found, action)
+	}
+
+	sort.Strings(found)
+
+	return found
+}
+
+func isIAMOrSTS(action string) bool {
+	return strings.HasPrefix(action, "iam:") || strings.HasPrefix(action, "sts:")
+}
+
+// sortedUnique returns the sorted, deduplicated contents of s. Pike's scan
+// output can list the same action more than once within a statement (e.g.
+// several attributes on one resource all requiring iam:GetRole); a
+// rendered policy document shouldn't repeat it.
+func sortedUnique(s []string) []string {
+	seen := make(map[string]bool, len(s))
+
+	var out []string
+
+	for _, v := range s {
+		if seen[v] {
+			continue
+		}
+
+		seen[v] = true
+
+		out = append(out, v)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+func firstAction(s Statement) string {
+	if len(s.Action) == 0 {
+		return ""
+	}
+
+	return s.Action[0]
+}

--- a/internal/bootstrap/render/deploy_policy_test.go
+++ b/internal/bootstrap/render/deploy_policy_test.go
@@ -1,0 +1,162 @@
+package render_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+func TestDeployPolicy(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{
+		Statements: []policy.Statement{
+			{Actions: []string{"iam:CreateRole", "iam:GetRole"}, Resources: []string{"*"}},
+			{Actions: []string{"ec2:RunInstances", "ec2:DescribeInstances"}, Resources: []string{"*"}},
+		},
+	}
+
+	doc := render.DeployPolicy(p)
+
+	if doc.Version != "2012-10-17" {
+		t.Errorf("Version = %q, want 2012-10-17", doc.Version)
+	}
+
+	if len(doc.Statements) != 2 {
+		t.Fatalf("len(Statements) = %d, want 2", len(doc.Statements))
+	}
+
+	// Statements ordered by first action: "ec2:..." sorts before "iam:...".
+	if got := doc.Statements[0].Action; len(got) != 2 || got[0] != "ec2:DescribeInstances" || got[1] != "ec2:RunInstances" {
+		t.Errorf("Statements[0].Action = %v, want sorted [ec2:DescribeInstances ec2:RunInstances]", got)
+	}
+
+	if got := doc.Statements[1].Action; len(got) != 2 || got[0] != "iam:CreateRole" || got[1] != "iam:GetRole" {
+		t.Errorf("Statements[1].Action = %v, want sorted [iam:CreateRole iam:GetRole]", got)
+	}
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" {
+			t.Errorf("Statement.Effect = %q, want Allow (deploy-policy carries no deny semantics)", s.Effect)
+		}
+	}
+}
+
+func TestDeployPolicy_DropsEmptyStatements(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{
+		Statements: []policy.Statement{
+			{Actions: nil, Resources: []string{"*"}},
+			{Actions: []string{"iam:GetRole"}, Resources: []string{"*"}},
+		},
+	}
+
+	doc := render.DeployPolicy(p)
+
+	if len(doc.Statements) != 1 {
+		t.Fatalf("len(Statements) = %d, want 1 (the actionless statement should be dropped)", len(doc.Statements))
+	}
+}
+
+func TestDeployPolicy_DeduplicatesWithinAStatement(t *testing.T) {
+	t.Parallel()
+
+	// Pike's real scan output repeats an action within a statement when
+	// multiple attributes on one resource all require it (e.g. several
+	// attributes on aws_iam_role all requiring iam:GetRole).
+	p := policy.Policy{
+		Statements: []policy.Statement{
+			{Actions: []string{"iam:GetRole", "iam:PassRole", "iam:GetRole", "iam:PassRole"}, Resources: []string{"*", "*"}},
+		},
+	}
+
+	doc := render.DeployPolicy(p)
+
+	if len(doc.Statements) != 1 {
+		t.Fatalf("len(Statements) = %d, want 1", len(doc.Statements))
+	}
+
+	got := doc.Statements[0].Action
+	want := []string{"iam:GetRole", "iam:PassRole"}
+
+	if len(got) != len(want) {
+		t.Fatalf("Action = %v, want %v (deduplicated)", got, want)
+	}
+
+	for i, a := range want {
+		if got[i] != a {
+			t.Errorf("Action[%d] = %q, want %q", i, got[i], a)
+		}
+	}
+}
+
+func TestDeployPolicy_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{
+		Statements: []policy.Statement{
+			{Actions: []string{"s3:PutObject", "s3:GetObject"}, Resources: []string{"*"}},
+			{Actions: []string{"iam:CreateRole"}, Resources: []string{"*"}},
+		},
+	}
+
+	first, err := json.Marshal(render.DeployPolicy(p))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		got, err := json.Marshal(render.DeployPolicy(p))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(got) != string(first) {
+			t.Fatalf("run %d: DeployPolicy() rendered differently:\n%s\nvs\n%s", i, got, first)
+		}
+	}
+}
+
+func TestEscalationActions(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{
+		Statements: []policy.Statement{
+			{Actions: []string{
+				"iam:GetRole",               // read — excluded
+				"iam:CreateRole",            // escalation-sensitive
+				"iam:PassRole",              // escalation-sensitive
+				"ec2:DescribeInstances",     // not IAM/STS at all — excluded
+				"ec2:RunInstances",          // not IAM/STS at all — excluded
+				"sts:GetCallerIdentity",     // read — excluded
+				"iam:UpdateRoleDescription", // unmapped IAM write — still escalation-sensitive
+			}},
+		},
+	}
+
+	got := render.EscalationActions(p)
+
+	want := []string{"iam:CreateRole", "iam:PassRole", "iam:UpdateRoleDescription"}
+	if len(got) != len(want) {
+		t.Fatalf("EscalationActions() = %v, want %v", got, want)
+	}
+
+	for i, action := range want {
+		if got[i] != action {
+			t.Errorf("EscalationActions()[%d] = %q, want %q", i, got[i], action)
+		}
+	}
+}
+
+func TestEscalationActions_Empty(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"ec2:DescribeInstances", "iam:GetRole"}}}}
+
+	if got := render.EscalationActions(p); len(got) != 0 {
+		t.Errorf("EscalationActions() = %v, want empty", got)
+	}
+}

--- a/internal/bootstrap/render/trust_policy.go
+++ b/internal/bootstrap/render/trust_policy.go
@@ -1,0 +1,99 @@
+package render
+
+import (
+	"fmt"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+)
+
+// UnsupportedPrincipalTypeError is returned for any principal.type other
+// than "iam-user" — spec section 2.2 excludes IAM Identity Center source
+// principals from v0.1.
+type UnsupportedPrincipalTypeError struct {
+	Type string
+}
+
+func (e *UnsupportedPrincipalTypeError) Error() string {
+	return fmt.Sprintf("unsupported principal.type %q (only \"iam-user\" is implemented in v0.1)", e.Type)
+}
+
+// TrustDocument is an IAM role trust policy (assume-role policy
+// document). Unlike Document, its statements are Principal-based rather
+// than Resource-based, and its conditions can use operators Document's
+// Condition doesn't need (Bool, NumericLessThanEquals) — so it's a
+// distinct type rather than a variant of Statement.
+type TrustDocument struct {
+	Version   string           `json:"Version"`
+	Statement []TrustStatement `json:"Statement"`
+}
+
+// TrustStatement is a single statement in a TrustDocument.
+type TrustStatement struct {
+	Sid       string            `json:"Sid"`
+	Effect    string            `json:"Effect"`
+	Principal map[string]string `json:"Principal"`
+	Action    string            `json:"Action"`
+	Condition *TrustCondition   `json:"Condition,omitempty"`
+}
+
+// TrustCondition covers the two operators the MFA-enforced trust policy
+// needs (spec section 14). encoding/json sorts map keys, so this stays
+// canonical without extra work.
+type TrustCondition struct {
+	Bool                  map[string]string `json:"Bool,omitempty"`
+	NumericLessThanEquals map[string]string `json:"NumericLessThanEquals,omitempty"`
+}
+
+// TrustPolicy renders trust-policy.json: the MFA-constrained deploy-role
+// trust policy that lets the configured source principal assume it
+// (spec section 14).
+func TrustPolicy(cfg *config.Config) (TrustDocument, error) {
+	if cfg.Principal.Type != "iam-user" {
+		return TrustDocument{}, &UnsupportedPrincipalTypeError{Type: cfg.Principal.Type}
+	}
+
+	statement := TrustStatement{
+		Sid:       "AssumeWithMFA",
+		Effect:    "Allow",
+		Principal: map[string]string{"AWS": userARN(cfg, cfg.Principal.Name)},
+		Action:    "sts:AssumeRole",
+	}
+
+	if cfg.Principal.MFA.Required {
+		condition := &TrustCondition{Bool: map[string]string{"aws:MultiFactorAuthPresent": "true"}}
+
+		if cfg.Principal.MFA.MaxAgeSeconds > 0 {
+			condition.NumericLessThanEquals = map[string]string{
+				"aws:MultiFactorAuthAge": fmt.Sprintf("%d", cfg.Principal.MFA.MaxAgeSeconds),
+			}
+		}
+
+		statement.Condition = condition
+	}
+
+	return TrustDocument{Version: policyVersion, Statement: []TrustStatement{statement}}, nil
+}
+
+// AssumeRolePolicy renders assume-role-policy.json: the minimal
+// sts:AssumeRole grant for the source principal (spec section 14) —
+// deliberately nothing more, matching the source-principal policy's own
+// design constraint ("grants only sts:AssumeRole").
+func AssumeRolePolicy(cfg *config.Config) Document {
+	return Document{
+		Version: policyVersion,
+		Statements: []Statement{{
+			Sid:      "AssumeTerraformDeployRole",
+			Effect:   "Allow",
+			Action:   []string{"sts:AssumeRole"},
+			Resource: []string{deployRoleARN(cfg)},
+		}},
+	}
+}
+
+func userARN(cfg *config.Config, name string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:user/%s", cfg.AWS.Partition, cfg.AWS.AccountID, name)
+}
+
+func deployRoleARN(cfg *config.Config) string {
+	return fmt.Sprintf("arn:%s:iam::%s:role%s%s", cfg.AWS.Partition, cfg.AWS.AccountID, cfg.DeployRole.Path, cfg.DeployRole.Name)
+}

--- a/internal/bootstrap/render/trust_policy_test.go
+++ b/internal/bootstrap/render/trust_policy_test.go
@@ -1,0 +1,110 @@
+package render_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{
+		AWS: config.AWSConfig{AccountID: "123456789012", Partition: "aws"},
+		Principal: config.PrincipalConfig{
+			Type: "iam-user",
+			Name: "cli-user",
+			MFA:  config.MFAConfig{Required: true, MaxAgeSeconds: 3600},
+		},
+		DeployRole: config.DeployRoleConfig{Name: "TerraformDeployRole", Path: "/terraform-deploy/"},
+	}
+}
+
+func TestTrustPolicy(t *testing.T) {
+	t.Parallel()
+
+	doc, err := render.TrustPolicy(testConfig())
+	if err != nil {
+		t.Fatalf("TrustPolicy() error = %v", err)
+	}
+
+	if len(doc.Statement) != 1 {
+		t.Fatalf("len(Statement) = %d, want 1", len(doc.Statement))
+	}
+
+	s := doc.Statement[0]
+
+	if s.Principal["AWS"] != "arn:aws:iam::123456789012:user/cli-user" {
+		t.Errorf("Principal[AWS] = %q, want the user ARN", s.Principal["AWS"])
+	}
+
+	if s.Action != "sts:AssumeRole" {
+		t.Errorf("Action = %q, want sts:AssumeRole", s.Action)
+	}
+
+	if s.Condition == nil {
+		t.Fatal("Condition = nil, want MFA condition since principal.mfa.required is true")
+	}
+
+	if s.Condition.Bool["aws:MultiFactorAuthPresent"] != "true" {
+		t.Errorf("Condition.Bool[aws:MultiFactorAuthPresent] = %q, want \"true\"", s.Condition.Bool["aws:MultiFactorAuthPresent"])
+	}
+
+	if s.Condition.NumericLessThanEquals["aws:MultiFactorAuthAge"] != "3600" {
+		t.Errorf("Condition.NumericLessThanEquals[aws:MultiFactorAuthAge] = %q, want \"3600\"", s.Condition.NumericLessThanEquals["aws:MultiFactorAuthAge"])
+	}
+}
+
+func TestTrustPolicy_MFANotRequired(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.Principal.MFA.Required = false
+
+	doc, err := render.TrustPolicy(cfg)
+	if err != nil {
+		t.Fatalf("TrustPolicy() error = %v", err)
+	}
+
+	if doc.Statement[0].Condition != nil {
+		t.Error("Condition present despite principal.mfa.required = false")
+	}
+}
+
+func TestTrustPolicy_UnsupportedPrincipalType(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.Principal.Type = "identity-center"
+
+	_, err := render.TrustPolicy(cfg)
+
+	var target *render.UnsupportedPrincipalTypeError
+	if !errors.As(err, &target) {
+		t.Fatalf("TrustPolicy() error = %v, want *UnsupportedPrincipalTypeError", err)
+	}
+}
+
+func TestAssumeRolePolicy(t *testing.T) {
+	t.Parallel()
+
+	doc := render.AssumeRolePolicy(testConfig())
+
+	if len(doc.Statements) != 1 {
+		t.Fatalf("len(Statements) = %d, want 1", len(doc.Statements))
+	}
+
+	s := doc.Statements[0]
+
+	if len(s.Action) != 1 || s.Action[0] != "sts:AssumeRole" {
+		t.Errorf("Action = %v, want [sts:AssumeRole]", s.Action)
+	}
+
+	if len(s.Resource) != 1 || s.Resource[0] != "arn:aws:iam::123456789012:role/terraform-deploy/TerraformDeployRole" {
+		t.Errorf("Resource = %v, want the deploy role ARN", s.Resource)
+	}
+
+	if s.Condition != nil {
+		t.Error("Condition present — the source-principal policy must grant only sts:AssumeRole, nothing conditional")
+	}
+}

--- a/internal/bootstrap/render/workload_boundary.go
+++ b/internal/bootstrap/render/workload_boundary.go
@@ -1,0 +1,40 @@
+package render
+
+import (
+	"fmt"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+)
+
+// UnsupportedWorkloadBoundaryModeError is returned when
+// policies.workload_boundary.mode isn't one v0.1 knows how to render.
+// Only "allowlist" is implemented; "infer" is spec section 13.3's future
+// mode, not yet built.
+type UnsupportedWorkloadBoundaryModeError struct {
+	Mode string
+}
+
+func (e *UnsupportedWorkloadBoundaryModeError) Error() string {
+	return fmt.Sprintf("unsupported workload_boundary.mode %q (only \"allowlist\" is implemented)", e.Mode)
+}
+
+// WorkloadBoundary renders workload-boundary.json: the maximum
+// permissions for Terraform-created workload roles. Per spec section
+// 13.1, this comes entirely from explicit configuration — it must not be
+// derived from the deploy policy, so unlike DeployPolicy/DeployBoundary
+// this takes no scanned Policy at all.
+func WorkloadBoundary(cfg *config.Config) (Document, error) {
+	if cfg.Policies.WorkloadBoundary.Mode != "allowlist" {
+		return Document{}, &UnsupportedWorkloadBoundaryModeError{Mode: cfg.Policies.WorkloadBoundary.Mode}
+	}
+
+	return Document{
+		Version: policyVersion,
+		Statements: []Statement{{
+			Sid:      "TerraformWorkloadBoundary",
+			Effect:   "Allow",
+			Action:   sortedUnique(cfg.Policies.WorkloadBoundary.AllowedActions),
+			Resource: []string{"*"},
+		}},
+	}, nil
+}

--- a/internal/bootstrap/render/workload_boundary_test.go
+++ b/internal/bootstrap/render/workload_boundary_test.go
@@ -1,0 +1,62 @@
+package render_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+)
+
+func TestWorkloadBoundary(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Policies: config.PoliciesConfig{
+			WorkloadBoundary: config.WorkloadBoundaryConfig{
+				Mode:           "allowlist",
+				AllowedActions: []string{"logs:PutLogEvents", "ecr:GetAuthorizationToken"},
+			},
+		},
+	}
+
+	doc, err := render.WorkloadBoundary(cfg)
+	if err != nil {
+		t.Fatalf("WorkloadBoundary() error = %v", err)
+	}
+
+	if len(doc.Statements) != 1 {
+		t.Fatalf("len(Statements) = %d, want 1", len(doc.Statements))
+	}
+
+	s := doc.Statements[0]
+	if s.Effect != "Allow" {
+		t.Errorf("Effect = %q, want Allow", s.Effect)
+	}
+
+	want := []string{"ecr:GetAuthorizationToken", "logs:PutLogEvents"}
+	if len(s.Action) != len(want) || s.Action[0] != want[0] || s.Action[1] != want[1] {
+		t.Errorf("Action = %v, want sorted %v", s.Action, want)
+	}
+
+	if len(s.Resource) != 1 || s.Resource[0] != "*" {
+		t.Errorf("Resource = %v, want [*]", s.Resource)
+	}
+}
+
+func TestWorkloadBoundary_UnsupportedMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Policies: config.PoliciesConfig{
+			WorkloadBoundary: config.WorkloadBoundaryConfig{Mode: "infer"},
+		},
+	}
+
+	_, err := render.WorkloadBoundary(cfg)
+
+	var target *render.UnsupportedWorkloadBoundaryModeError
+	if !errors.As(err, &target) {
+		t.Fatalf("WorkloadBoundary() error = %v, want *UnsupportedWorkloadBoundaryModeError", err)
+	}
+}

--- a/internal/bootstrap/report/report.go
+++ b/internal/bootstrap/report/report.go
@@ -1,0 +1,249 @@
+// Package report builds report.json (spec section 19): the inputs,
+// versions, findings, rewrites, warnings and artifact hashes for one
+// generate run. It never calls time.Now() itself — GeneratedAt is a
+// caller-supplied value — so Generate stays a pure function and its
+// output is reproducible in tests.
+package report
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/classify"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/validate"
+)
+
+const SchemaVersion = 1
+
+// Report is report.json's top-level shape.
+type Report struct {
+	SchemaVersion int       `json:"schema_version"`
+	GeneratedAt   string    `json:"generated_at"`
+	Generator     Generator `json:"generator"`
+	Scanner       Scanner   `json:"scanner"`
+	Inputs        Inputs    `json:"inputs"`
+	Summary       Summary   `json:"summary"`
+	Rewrites      []Rewrite `json:"rewrites"`
+	Warnings      []Warning `json:"warnings"`
+	Artifacts     Artifacts `json:"artifacts"`
+}
+
+type Generator struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Scanner struct {
+	Name            string `json:"name"`
+	MappingRevision string `json:"mapping_revision"`
+}
+
+type Inputs struct {
+	TerraformDirectory string `json:"terraform_directory"`
+	ConfigHash         string `json:"config_hash"`
+}
+
+type Summary struct {
+	TotalActions      int `json:"total_actions"`
+	IAMActions        int `json:"iam_actions"`
+	EscalationActions int `json:"escalation_actions"`
+	BlockingFindings  int `json:"blocking_findings"`
+}
+
+// Rewrite records one escalation-sensitive action that got a constrained
+// replacement statement during deploy-boundary transformation, rather
+// than being denied outright or passed through as a plain read.
+type Rewrite struct {
+	Action         string `json:"action"`
+	Classification string `json:"classification"`
+	Rule           string `json:"rule"`
+}
+
+type Warning struct {
+	Code    string `json:"code"`
+	Service string `json:"service,omitempty"`
+}
+
+type Artifacts struct {
+	DeployPolicy     string `json:"deploy_policy"`
+	DeployBoundary   string `json:"deploy_boundary"`
+	WorkloadBoundary string `json:"workload_boundary"`
+}
+
+// rewriteRule maps the classify.Class values that get a constructive
+// replacement statement (spec section 12) to that statement's Sid. Classes
+// not listed here either pass through unchanged (Read) or are denied
+// outright (BoundaryMutation, PolicyMutation, HumanPrincipal,
+// Organization) — neither is a "rewrite" in report.json's sense.
+var rewriteRule = map[classify.Class]string{
+	classify.RoleCreate:        "CreateRoleWithRequiredBoundary",
+	classify.RolePolicyWrite:   "ManageTerraformRoles",
+	classify.PassRole:          "PassManagedRolesToApprovedServices",
+	classify.ServiceLinkedRole: "CreateApprovedServiceLinkedRoles",
+}
+
+// Input bundles everything one generate run's report needs. GeneratedAt
+// and GeneratorVersion are supplied by the caller rather than read from
+// time.Now()/a package-level version var, so Generate has no hidden
+// inputs and its output is exactly reproducible given the same Input.
+type Input struct {
+	GeneratedAt        time.Time
+	GeneratorVersion   string
+	ScannerName        string
+	MappingRevision    string
+	TerraformDirectory string
+	ConfigBytes        []byte
+	DeployPolicy       render.Document
+	DeployBoundary     render.Document
+	WorkloadBoundary   render.Document
+	Findings           []validate.Finding
+}
+
+// Generate builds the report for one generate run.
+func Generate(in Input) (Report, error) {
+	deployPolicyHash, err := canonicalHash(in.DeployPolicy)
+	if err != nil {
+		return Report{}, fmt.Errorf("hashing deploy policy: %w", err)
+	}
+
+	deployBoundaryHash, err := canonicalHash(in.DeployBoundary)
+	if err != nil {
+		return Report{}, fmt.Errorf("hashing deploy boundary: %w", err)
+	}
+
+	workloadBoundaryHash, err := canonicalHash(in.WorkloadBoundary)
+	if err != nil {
+		return Report{}, fmt.Errorf("hashing workload boundary: %w", err)
+	}
+
+	blocking := 0
+
+	for _, f := range in.Findings {
+		if f.Severity == validate.Blocking {
+			blocking++
+		}
+	}
+
+	return Report{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   in.GeneratedAt.UTC().Format(time.RFC3339),
+		Generator:     Generator{Name: "pike", Version: in.GeneratorVersion},
+		Scanner:       Scanner{Name: in.ScannerName, MappingRevision: in.MappingRevision},
+		Inputs: Inputs{
+			TerraformDirectory: in.TerraformDirectory,
+			ConfigHash:         "sha256:" + sha256Hex(in.ConfigBytes),
+		},
+		Summary:  summarize(in.DeployPolicy, blocking),
+		Rewrites: rewrites(in.DeployPolicy),
+		Warnings: warnings(in.Findings),
+		Artifacts: Artifacts{
+			DeployPolicy:     deployPolicyHash,
+			DeployBoundary:   deployBoundaryHash,
+			WorkloadBoundary: workloadBoundaryHash,
+		},
+	}, nil
+}
+
+func summarize(deployPolicy render.Document, blockingFindings int) Summary {
+	totalActions := 0
+	iamActions := 0
+
+	for _, s := range deployPolicy.Statements {
+		totalActions += len(s.Action)
+
+		for _, action := range s.Action {
+			if isIAMOrSTS(action) {
+				iamActions++
+			}
+		}
+	}
+
+	escalation := escalationActions(deployPolicy)
+
+	return Summary{
+		TotalActions:      totalActions,
+		IAMActions:        iamActions,
+		EscalationActions: len(escalation),
+		BlockingFindings:  blockingFindings,
+	}
+}
+
+func rewrites(deployPolicy render.Document) []Rewrite {
+	var out []Rewrite
+
+	for _, action := range escalationActions(deployPolicy) {
+		class := classify.Classify(action)
+
+		rule, ok := rewriteRule[class]
+		if !ok {
+			continue
+		}
+
+		out = append(out, Rewrite{Action: action, Classification: string(class), Rule: rule})
+	}
+
+	return out
+}
+
+func warnings(findings []validate.Finding) []Warning {
+	var out []Warning
+
+	for _, f := range findings {
+		if f.Severity == validate.Warning {
+			out = append(out, Warning{Code: f.Code})
+		}
+	}
+
+	return out
+}
+
+// escalationActions re-derives render.EscalationActions' result directly
+// from a Document rather than a policy.Policy — the deploy policy has
+// already been rendered by the time report.Generate runs, and pulling
+// policy.Policy back in just to re-derive the same actions would add a
+// dependency this package doesn't otherwise need.
+func escalationActions(doc render.Document) []string {
+	var found []string
+
+	seen := make(map[string]bool)
+
+	for _, s := range doc.Statements {
+		for _, action := range s.Action {
+			if seen[action] || !isIAMOrSTS(action) {
+				continue
+			}
+
+			seen[action] = true
+
+			if classify.Classify(action) != classify.Read {
+				found = append(found, action)
+			}
+		}
+	}
+
+	return found
+}
+
+func isIAMOrSTS(action string) bool {
+	return strings.HasPrefix(action, "iam:") || strings.HasPrefix(action, "sts:")
+}
+
+func canonicalHash(doc render.Document) (string, error) {
+	data, err := json.Marshal(doc)
+	if err != nil {
+		return "", err
+	}
+
+	return "sha256:" + sha256Hex(data), nil
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/bootstrap/report/report_test.go
+++ b/internal/bootstrap/report/report_test.go
@@ -1,0 +1,181 @@
+package report_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/report"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/validate"
+)
+
+func fixedTime() time.Time {
+	return time.Date(2026, 7, 30, 0, 0, 0, 0, time.UTC)
+}
+
+func baseInput() report.Input {
+	deployPolicy := render.Document{Version: "2012-10-17", Statements: []render.Statement{
+		{Sid: "S0", Effect: "Allow", Action: []string{"ec2:DescribeInstances", "ec2:RunInstances"}, Resource: []string{"*"}},
+		{Sid: "S1", Effect: "Allow", Action: []string{"iam:CreateRole", "iam:GetRole", "iam:PassRole"}, Resource: []string{"*"}},
+	}}
+
+	deployBoundary := render.Document{Version: "2012-10-17", Statements: []render.Statement{
+		{Sid: "CreateRoleWithRequiredBoundary", Effect: "Allow", Action: []string{"iam:CreateRole"}, Resource: []string{"arn:aws:iam::123456789012:role/terraform-managed/*"}},
+	}}
+
+	workloadBoundary := render.Document{Version: "2012-10-17", Statements: []render.Statement{
+		{Sid: "TerraformWorkloadBoundary", Effect: "Allow", Action: []string{"logs:PutLogEvents"}, Resource: []string{"*"}},
+	}}
+
+	return report.Input{
+		GeneratedAt:        fixedTime(),
+		GeneratorVersion:   "0.1.0",
+		ScannerName:        "pike",
+		MappingRevision:    "rev1",
+		TerraformDirectory: "./infra",
+		ConfigBytes:        []byte("version: 1\n"),
+		DeployPolicy:       deployPolicy,
+		DeployBoundary:     deployBoundary,
+		WorkloadBoundary:   workloadBoundary,
+		Findings: []validate.Finding{
+			{Code: "WORKLOAD_ALLOWLIST_WILDCARD", Severity: validate.Warning, Message: "warn"},
+		},
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	t.Parallel()
+
+	r, err := report.Generate(baseInput())
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	if r.SchemaVersion != report.SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", r.SchemaVersion, report.SchemaVersion)
+	}
+
+	if r.GeneratedAt != "2026-07-30T00:00:00Z" {
+		t.Errorf("GeneratedAt = %q, want 2026-07-30T00:00:00Z", r.GeneratedAt)
+	}
+
+	if r.Generator.Name != "pike" || r.Generator.Version != "0.1.0" {
+		t.Errorf("Generator = %+v, want {pike 0.1.0}", r.Generator)
+	}
+
+	if r.Scanner.Name != "pike" || r.Scanner.MappingRevision != "rev1" {
+		t.Errorf("Scanner = %+v, want {pike rev1}", r.Scanner)
+	}
+
+	if r.Inputs.TerraformDirectory != "./infra" {
+		t.Errorf("Inputs.TerraformDirectory = %q, want ./infra", r.Inputs.TerraformDirectory)
+	}
+
+	if r.Inputs.ConfigHash == "" || r.Inputs.ConfigHash[:7] != "sha256:" {
+		t.Errorf("Inputs.ConfigHash = %q, want a sha256: prefix", r.Inputs.ConfigHash)
+	}
+
+	// total_actions: 2 (ec2) + 3 (iam) = 5. iam_actions: CreateRole, GetRole, PassRole = 3.
+	// escalation_actions: CreateRole, PassRole (GetRole is a read) = 2.
+	if r.Summary.TotalActions != 5 {
+		t.Errorf("Summary.TotalActions = %d, want 5", r.Summary.TotalActions)
+	}
+
+	if r.Summary.IAMActions != 3 {
+		t.Errorf("Summary.IAMActions = %d, want 3", r.Summary.IAMActions)
+	}
+
+	if r.Summary.EscalationActions != 2 {
+		t.Errorf("Summary.EscalationActions = %d, want 2", r.Summary.EscalationActions)
+	}
+
+	if r.Summary.BlockingFindings != 0 {
+		t.Errorf("Summary.BlockingFindings = %d, want 0 (only a warning finding was given)", r.Summary.BlockingFindings)
+	}
+
+	wantRewrites := map[string]string{
+		"iam:CreateRole": "CreateRoleWithRequiredBoundary",
+		"iam:PassRole":   "PassManagedRolesToApprovedServices",
+	}
+
+	if len(r.Rewrites) != len(wantRewrites) {
+		t.Fatalf("Rewrites = %+v, want entries for %v", r.Rewrites, wantRewrites)
+	}
+
+	for _, rw := range r.Rewrites {
+		if wantRule, ok := wantRewrites[rw.Action]; !ok || wantRule != rw.Rule {
+			t.Errorf("Rewrite for %q = %+v, want rule %q", rw.Action, rw, wantRewrites[rw.Action])
+		}
+	}
+
+	if len(r.Warnings) != 1 || r.Warnings[0].Code != "WORKLOAD_ALLOWLIST_WILDCARD" {
+		t.Errorf("Warnings = %+v, want one WORKLOAD_ALLOWLIST_WILDCARD entry", r.Warnings)
+	}
+
+	for name, hash := range map[string]string{
+		"DeployPolicy":     r.Artifacts.DeployPolicy,
+		"DeployBoundary":   r.Artifacts.DeployBoundary,
+		"WorkloadBoundary": r.Artifacts.WorkloadBoundary,
+	} {
+		if hash == "" || hash[:7] != "sha256:" {
+			t.Errorf("Artifacts.%s = %q, want a sha256: prefix", name, hash)
+		}
+	}
+}
+
+func TestGenerate_BlockingFindingsCounted(t *testing.T) {
+	t.Parallel()
+
+	in := baseInput()
+	in.Findings = []validate.Finding{
+		{Code: "RMP-E001", Severity: validate.Blocking},
+		{Code: "RMP-E002", Severity: validate.Blocking},
+		{Code: "WORKLOAD_ALLOWLIST_WILDCARD", Severity: validate.Warning},
+	}
+
+	r, err := report.Generate(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.Summary.BlockingFindings != 2 {
+		t.Errorf("Summary.BlockingFindings = %d, want 2", r.Summary.BlockingFindings)
+	}
+
+	if len(r.Warnings) != 1 {
+		t.Errorf("Warnings = %+v, want exactly the one warning-severity finding", r.Warnings)
+	}
+}
+
+func TestGenerate_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	in := baseInput()
+
+	first, err := report.Generate(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		r, err := report.Generate(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(got) != string(firstJSON) {
+			t.Fatalf("run %d: Generate() rendered differently:\n%s\nvs\n%s", i, got, firstJSON)
+		}
+	}
+}

--- a/internal/bootstrap/transform/deploy_boundary.go
+++ b/internal/bootstrap/transform/deploy_boundary.go
@@ -1,0 +1,354 @@
+// Package transform implements deploy-boundary.json generation (spec
+// section 12): the deploy policy's requested permissions, rewritten so
+// every IAM/STS write is either scoped to the managed-role path with the
+// required conditions, or explicitly denied. Non-IAM permissions and
+// read-only IAM/STS actions pass through unchanged; everything else in
+// the transformation order is unconditional on what Pike actually
+// detected — the mandatory denies exist to hold the invariants in
+// spec section 4.2 regardless of the scanned Terraform.
+package transform
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/classify"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+// PassRoleServicesRequiredError is returned when the scanned policy
+// requires iam:PassRole but pass_role.allowed_services is empty (spec
+// section 12.3: "Generation fails if iam:PassRole is detected but no
+// approved service is configured.").
+type PassRoleServicesRequiredError struct{}
+
+func (*PassRoleServicesRequiredError) Error() string {
+	return "iam:PassRole detected but pass_role.allowed_services is empty"
+}
+
+// ServiceLinkedRoleServicesRequiredError is returned when the scanned
+// policy requires iam:CreateServiceLinkedRole but
+// service_linked_roles.allowed_services is empty (spec section 12.4).
+type ServiceLinkedRoleServicesRequiredError struct{}
+
+func (*ServiceLinkedRoleServicesRequiredError) Error() string {
+	return "iam:CreateServiceLinkedRole detected but service_linked_roles.allowed_services is empty"
+}
+
+// UnknownIAMActionError is returned when the scanned policy requires an
+// IAM/STS action the classifier doesn't recognize and
+// security.fail_on_unknown_iam_action is true (the default). Spec
+// section 4.2 rule 7: unknown IAM write actions fail generation by
+// default rather than being silently allowed into the boundary.
+type UnknownIAMActionError struct {
+	Action string
+}
+
+func (e *UnknownIAMActionError) Error() string {
+	return fmt.Sprintf("unclassified IAM/STS action %q: refusing to generate a boundary that silently allows it", e.Action)
+}
+
+// accessKeyActions and humanIdentityActions split classify.HumanPrincipal
+// (one combined class for classification purposes) back into the two
+// groups pike.yaml's security.deny_human_principal_management and
+// security.deny_access_key_management flags each control independently.
+var (
+	humanIdentityActions = []string{
+		"iam:CreateUser",
+		"iam:DeleteUser",
+		"iam:UpdateUser",
+		"iam:CreateLoginProfile",
+		"iam:UpdateLoginProfile",
+		"iam:DeleteLoginProfile",
+		"iam:CreateVirtualMFADevice",
+		"iam:DeactivateMFADevice",
+		"iam:DeleteVirtualMFADevice",
+		"iam:EnableMFADevice",
+		"iam:ResyncMFADevice",
+	}
+
+	accessKeyActions = []string{
+		"iam:CreateAccessKey",
+		"iam:UpdateAccessKey",
+		"iam:DeleteAccessKey",
+	}
+)
+
+// managedRoleLifecycleActions are always included in ManageTerraformRoles
+// when it's generated at all, regardless of what Pike detected — the
+// deploy role needs them to fulfil the boundary lifecycle itself (spec
+// section 12.2: "Actions required for boundary lifecycle").
+var managedRoleLifecycleActions = []string{"iam:PutRolePermissionsBoundary"}
+
+// DeployBoundary transforms a scanned Policy into deploy-boundary.json:
+// the maximum permissions the deploy role may hold once bootstrapped.
+func DeployBoundary(p policy.Policy, cfg *config.Config) (render.Document, error) {
+	grouped := groupByClass(p)
+
+	if cfg.Security.FailOnUnknownIAMAction {
+		for _, action := range grouped[classify.Unknown] {
+			return render.Document{}, &UnknownIAMActionError{Action: action}
+		}
+	}
+
+	var statements []render.Statement
+
+	statements = append(statements, nonIAMStatements(p)...)
+
+	if read := grouped[classify.Read]; len(read) > 0 {
+		statements = append(statements, render.Statement{
+			Sid:      "IAMRead",
+			Effect:   "Allow",
+			Action:   read,
+			Resource: []string{"*"}, // no live account at generate time to scope further
+		})
+	}
+
+	managedRoleARN := roleARN(cfg, cfg.ManagedRoles.Path)
+
+	if len(grouped[classify.RoleCreate]) > 0 {
+		statements = append(statements, render.Statement{
+			Sid:      "CreateRoleWithRequiredBoundary",
+			Effect:   "Allow",
+			Action:   []string{"iam:CreateRole"},
+			Resource: []string{managedRoleARN},
+			Condition: &render.Condition{StringEquals: map[string]any{
+				"iam:PermissionsBoundary": namedPolicyARN(cfg, cfg.Policies.WorkloadBoundary.Path, cfg.Policies.WorkloadBoundary.Name),
+			}},
+		})
+	}
+
+	if manageActions := union(grouped[classify.RolePolicyWrite], managedRoleLifecycleActions); len(grouped[classify.RoleCreate]) > 0 || len(grouped[classify.RolePolicyWrite]) > 0 {
+		statements = append(statements, render.Statement{
+			Sid:      "ManageTerraformRoles",
+			Effect:   "Allow",
+			Action:   manageActions,
+			Resource: []string{managedRoleARN},
+		})
+	}
+
+	if len(grouped[classify.PassRole]) > 0 {
+		if len(cfg.PassRole.AllowedServices) == 0 {
+			return render.Document{}, &PassRoleServicesRequiredError{}
+		}
+
+		statements = append(statements, render.Statement{
+			Sid:      "PassManagedRolesToApprovedServices",
+			Effect:   "Allow",
+			Action:   []string{"iam:PassRole"},
+			Resource: []string{managedRoleARN},
+			Condition: &render.Condition{StringEquals: map[string]any{
+				"iam:PassedToService": sortedCopy(cfg.PassRole.AllowedServices),
+			}},
+		})
+	}
+
+	if len(grouped[classify.ServiceLinkedRole]) > 0 {
+		if len(cfg.ServiceLinkedRoles.AllowedServices) == 0 {
+			return render.Document{}, &ServiceLinkedRoleServicesRequiredError{}
+		}
+
+		statements = append(statements, render.Statement{
+			Sid:      "CreateApprovedServiceLinkedRoles",
+			Effect:   "Allow",
+			Action:   []string{"iam:CreateServiceLinkedRole"},
+			Resource: []string{"*"},
+			Condition: &render.Condition{StringEquals: map[string]any{
+				"iam:AWSServiceName": sortedCopy(cfg.ServiceLinkedRoles.AllowedServices),
+			}},
+		})
+	}
+
+	statements = append(statements, mandatoryDenies(cfg, managedRoleARN)...)
+
+	sort.Slice(statements, func(i, j int) bool { return statements[i].Sid < statements[j].Sid })
+
+	return render.Document{Version: "2012-10-17", Statements: statements}, nil
+}
+
+// mandatoryDenies returns the always-present deny statements security's
+// deny_* flags control (spec section 12.5). These are independent of
+// what Pike detected — they exist to hold section 4.2's invariants
+// (the deploy role can't remove or widen its own boundary, can't touch
+// human principals, access keys or org governance) regardless of the
+// Terraform being deployed.
+func mandatoryDenies(cfg *config.Config, managedRoleARN string) []render.Statement {
+	var denies []render.Statement
+
+	if cfg.Security.DenyBoundaryRemoval {
+		denies = append(denies, render.Statement{
+			Sid:      "DenyWorkloadBoundaryRemoval",
+			Effect:   "Deny",
+			Action:   []string{"iam:DeleteRolePermissionsBoundary"},
+			Resource: []string{managedRoleARN},
+		})
+	}
+
+	if cfg.Security.DenyBoundaryPolicyMutation {
+		denies = append(denies, render.Statement{
+			Sid:    "DenyBoundaryPolicyMutation",
+			Effect: "Deny",
+			Action: sortedCopy([]string{
+				"iam:CreatePolicyVersion",
+				"iam:DeletePolicyVersion",
+				"iam:SetDefaultPolicyVersion",
+				"iam:DeletePolicy",
+			}),
+			Resource: []string{policyPathARN(cfg, cfg.Policies.DeployBoundary.Path)},
+		})
+	}
+
+	if cfg.Security.DenyHumanPrincipalManagement {
+		denies = append(denies, render.Statement{
+			Sid:      "DenyHumanPrincipalManagement",
+			Effect:   "Deny",
+			Action:   sortedCopy(humanIdentityActions),
+			Resource: []string{"*"},
+		})
+	}
+
+	if cfg.Security.DenyAccessKeyManagement {
+		denies = append(denies, render.Statement{
+			Sid:      "DenyAccessKeyManagement",
+			Effect:   "Deny",
+			Action:   sortedCopy(accessKeyActions),
+			Resource: []string{"*"},
+		})
+	}
+
+	if cfg.Security.DenyOrganizationManagement {
+		denies = append(denies, render.Statement{
+			Sid:      "DenyOrganizationManagement",
+			Effect:   "Deny",
+			Action:   []string{"account:*", "organizations:*"},
+			Resource: []string{"*"},
+		})
+	}
+
+	return denies
+}
+
+// nonIAMStatements copies every statement of the scanned policy that
+// contains no IAM/STS actions through unchanged (transformation order
+// step 1) — the boundary must allow at least what non-IAM services need,
+// since it only restricts IAM.
+func nonIAMStatements(p policy.Policy) []render.Statement {
+	var statements []render.Statement
+
+	for i, s := range p.Statements {
+		var nonIAM []string
+
+		for _, action := range s.Actions {
+			if !isIAMOrSTS(action) {
+				nonIAM = append(nonIAM, action)
+			}
+		}
+
+		if len(nonIAM) == 0 {
+			continue
+		}
+
+		statements = append(statements, render.Statement{
+			Sid:      fmt.Sprintf("NonIAM%d", i),
+			Effect:   "Allow",
+			Action:   sortedUnique(nonIAM),
+			Resource: sortedUnique(s.Resources),
+		})
+	}
+
+	return statements
+}
+
+// groupByClass classifies every distinct IAM/STS action in p and groups
+// them by class, sorted within each group. Non-IAM/STS actions are
+// excluded entirely — they're handled by nonIAMStatements instead.
+func groupByClass(p policy.Policy) map[classify.Class][]string {
+	grouped := make(map[classify.Class][]string)
+	seen := make(map[string]bool)
+
+	for _, action := range p.Actions() {
+		if !isIAMOrSTS(action) || seen[action] {
+			continue
+		}
+
+		seen[action] = true
+		class := classify.Classify(action)
+		grouped[class] = append(grouped[class], action)
+	}
+
+	for class := range grouped {
+		sort.Strings(grouped[class])
+	}
+
+	return grouped
+}
+
+func isIAMOrSTS(action string) bool {
+	return strings.HasPrefix(action, "iam:") || strings.HasPrefix(action, "sts:")
+}
+
+func roleARN(cfg *config.Config, path string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:role%s*", cfg.AWS.Partition, cfg.AWS.AccountID, path)
+}
+
+func namedPolicyARN(cfg *config.Config, path, name string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:policy%s%s", cfg.AWS.Partition, cfg.AWS.AccountID, path, name)
+}
+
+func policyPathARN(cfg *config.Config, path string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:policy%s*", cfg.AWS.Partition, cfg.AWS.AccountID, path)
+}
+
+func sortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+
+	return out
+}
+
+// sortedUnique returns the sorted, deduplicated contents of s. Pike's
+// scan output can list the same action more than once within a
+// statement, and a rendered policy document shouldn't repeat it.
+func sortedUnique(s []string) []string {
+	seen := make(map[string]bool, len(s))
+
+	var out []string
+
+	for _, v := range s {
+		if seen[v] {
+			continue
+		}
+
+		seen[v] = true
+
+		out = append(out, v)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// union returns the sorted, deduplicated union of a and b.
+func union(a, b []string) []string {
+	seen := make(map[string]bool, len(a)+len(b))
+
+	var out []string
+
+	for _, s := range append(append([]string(nil), a...), b...) {
+		if seen[s] {
+			continue
+		}
+
+		seen[s] = true
+
+		out = append(out, s)
+	}
+
+	sort.Strings(out)
+
+	return out
+}

--- a/internal/bootstrap/transform/deploy_boundary.go
+++ b/internal/bootstrap/transform/deploy_boundary.go
@@ -77,12 +77,6 @@ var (
 	}
 )
 
-// managedRoleLifecycleActions are always included in ManageTerraformRoles
-// when it's generated at all, regardless of what Pike detected — the
-// deploy role needs them to fulfil the boundary lifecycle itself (spec
-// section 12.2: "Actions required for boundary lifecycle").
-var managedRoleLifecycleActions = []string{"iam:PutRolePermissionsBoundary"}
-
 // DeployBoundary transforms a scanned Policy into deploy-boundary.json:
 // the maximum permissions the deploy role may hold once bootstrapped.
 func DeployBoundary(p policy.Policy, cfg *config.Config) (render.Document, error) {
@@ -108,6 +102,7 @@ func DeployBoundary(p policy.Policy, cfg *config.Config) (render.Document, error
 	}
 
 	managedRoleARN := roleARN(cfg, cfg.ManagedRoles.Path)
+	workloadBoundaryARN := namedPolicyARN(cfg, cfg.Policies.WorkloadBoundary.Path, cfg.Policies.WorkloadBoundary.Name)
 
 	if len(grouped[classify.RoleCreate]) > 0 {
 		statements = append(statements, render.Statement{
@@ -116,17 +111,44 @@ func DeployBoundary(p policy.Policy, cfg *config.Config) (render.Document, error
 			Action:   []string{"iam:CreateRole"},
 			Resource: []string{managedRoleARN},
 			Condition: &render.Condition{StringEquals: map[string]any{
-				"iam:PermissionsBoundary": namedPolicyARN(cfg, cfg.Policies.WorkloadBoundary.Path, cfg.Policies.WorkloadBoundary.Name),
+				"iam:PermissionsBoundary": workloadBoundaryARN,
 			}},
 		})
 	}
 
-	if manageActions := union(grouped[classify.RolePolicyWrite], managedRoleLifecycleActions); len(grouped[classify.RoleCreate]) > 0 || len(grouped[classify.RolePolicyWrite]) > 0 {
+	rolePolicyWrite := grouped[classify.RolePolicyWrite]
+
+	// iam:PutRolePermissionsBoundary is deliberately excluded from
+	// ManageTerraformRoles (and given its own conditioned statement below)
+	// even when Pike detects it directly — an unconditioned grant of this
+	// action lets the deploy role re-point a role at a different, more
+	// permissive boundary policy, silently bypassing the boundary the
+	// CreateRole condition above and the boundary-tampering denies in
+	// mandatoryDenies exist to enforce. See MaintainRequiredBoundary.
+	if manageActions := removeAction(rolePolicyWrite, "iam:PutRolePermissionsBoundary"); len(manageActions) > 0 {
 		statements = append(statements, render.Statement{
 			Sid:      "ManageTerraformRoles",
 			Effect:   "Allow",
 			Action:   manageActions,
 			Resource: []string{managedRoleARN},
+		})
+	}
+
+	// The deploy role needs iam:PutRolePermissionsBoundary to maintain the
+	// boundary on roles it manages (e.g. Terraform reapplying an existing
+	// role's permissions_boundary attribute) whenever it creates or
+	// modifies roles at all (spec section 12.2: "Actions required for
+	// boundary lifecycle") — but only ever to (re)attach the one required
+	// workload boundary, never anything else.
+	if len(grouped[classify.RoleCreate]) > 0 || len(rolePolicyWrite) > 0 {
+		statements = append(statements, render.Statement{
+			Sid:      "MaintainRequiredBoundary",
+			Effect:   "Allow",
+			Action:   []string{"iam:PutRolePermissionsBoundary"},
+			Resource: []string{managedRoleARN},
+			Condition: &render.Condition{StringEquals: map[string]any{
+				"iam:PermissionsBoundary": workloadBoundaryARN,
+			}},
 		})
 	}
 
@@ -188,6 +210,19 @@ func mandatoryDenies(cfg *config.Config, managedRoleARN string) []render.Stateme
 	}
 
 	if cfg.Security.DenyBoundaryPolicyMutation {
+		// Covers both the deploy_boundary and workload_boundary policy
+		// paths, not just deploy_boundary's — they're free to be
+		// configured under different IAM paths (config.Validate only
+		// requires them distinct from deploy_role/managed_roles, not from
+		// each other), and the workload boundary is the one actually
+		// constraining roles CreateRoleWithRequiredBoundary/
+		// MaintainRequiredBoundary create. No statement currently grants
+		// iam:CreatePolicyVersion et al. at all (PolicyMutation-classified
+		// actions aren't wired into any Allow), so this is defense in
+		// depth rather than closing an active hole - but it means a
+		// future change that does grant one of these actions can't
+		// silently reopen the boundary via its content instead of its
+		// attachment.
 		denies = append(denies, render.Statement{
 			Sid:    "DenyBoundaryPolicyMutation",
 			Effect: "Deny",
@@ -197,7 +232,10 @@ func mandatoryDenies(cfg *config.Config, managedRoleARN string) []render.Stateme
 				"iam:SetDefaultPolicyVersion",
 				"iam:DeletePolicy",
 			}),
-			Resource: []string{policyPathARN(cfg, cfg.Policies.DeployBoundary.Path)},
+			Resource: sortedUnique([]string{
+				policyPathARN(cfg, cfg.Policies.DeployBoundary.Path),
+				policyPathARN(cfg, cfg.Policies.WorkloadBoundary.Path),
+			}),
 		})
 	}
 
@@ -332,20 +370,18 @@ func sortedUnique(s []string) []string {
 	return out
 }
 
-// union returns the sorted, deduplicated union of a and b.
-func union(a, b []string) []string {
-	seen := make(map[string]bool, len(a)+len(b))
-
+// removeAction returns a sorted copy of actions with target removed, if
+// present. Used to keep iam:PutRolePermissionsBoundary out of
+// ManageTerraformRoles regardless of whether it arrived there via direct
+// detection — it always gets its own conditioned statement instead (see
+// MaintainRequiredBoundary in DeployBoundary).
+func removeAction(actions []string, target string) []string {
 	var out []string
 
-	for _, s := range append(append([]string(nil), a...), b...) {
-		if seen[s] {
-			continue
+	for _, a := range actions {
+		if a != target {
+			out = append(out, a)
 		}
-
-		seen[s] = true
-
-		out = append(out, s)
 	}
 
 	sort.Strings(out)

--- a/internal/bootstrap/transform/deploy_boundary_test.go
+++ b/internal/bootstrap/transform/deploy_boundary_test.go
@@ -1,0 +1,474 @@
+package transform_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/transform"
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+// testConfig returns the spec section 7 reference config, so expected
+// ARNs in these tests match the ones spec section 12's examples show.
+func testConfig() *config.Config {
+	return &config.Config{
+		Version: 1,
+		AWS: config.AWSConfig{
+			AccountID: "123456789012",
+			Partition: "aws",
+			Region:    "ap-northeast-2",
+		},
+		Principal: config.PrincipalConfig{
+			MFA: config.MFAConfig{Required: true, Serial: "arn:aws:iam::123456789012:mfa/cli-user"},
+		},
+		DeployRole: config.DeployRoleConfig{Path: "/terraform-deploy/"},
+		ManagedRoles: config.ManagedRolesConfig{
+			Path: "/terraform-managed/",
+		},
+		Policies: config.PoliciesConfig{
+			Deploy:         config.PolicyConfig{Name: "TerraformDeployPolicy", Path: "/terraform-deploy/"},
+			DeployBoundary: config.PolicyConfig{Name: "TerraformDeployBoundary", Path: "/boundaries/"},
+			WorkloadBoundary: config.WorkloadBoundaryConfig{
+				Name: "TerraformWorkloadBoundary",
+				Path: "/boundaries/",
+				Mode: "allowlist",
+			},
+		},
+		PassRole:           config.PassRoleConfig{AllowedServices: []string{"ecs-tasks.amazonaws.com", "scheduler.amazonaws.com"}},
+		ServiceLinkedRoles: config.ServiceLinkedRolesConfig{AllowedServices: []string{"ecs.amazonaws.com"}},
+		Security: config.SecurityConfig{
+			FailOnUnknownIAMAction:       true,
+			DenyBoundaryRemoval:          true,
+			DenyBoundaryPolicyMutation:   true,
+			DenyHumanPrincipalManagement: true,
+			DenyAccessKeyManagement:      true,
+			DenyOrganizationManagement:   true,
+		},
+	}
+}
+
+func statementBySid(t *testing.T, doc []byte, sid string) map[string]any {
+	t.Helper()
+
+	var decoded struct {
+		Statement []map[string]any `json:"Statement"`
+	}
+
+	if err := json.Unmarshal(doc, &decoded); err != nil {
+		t.Fatalf("unmarshal document: %v", err)
+	}
+
+	for _, s := range decoded.Statement {
+		if s["Sid"] == sid {
+			return s
+		}
+	}
+
+	t.Fatalf("no statement with Sid %q in %s", sid, doc)
+
+	return nil
+}
+
+func TestDeployBoundary_CreateRole(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := statementBySid(t, raw, "CreateRoleWithRequiredBoundary")
+
+	if s["Effect"] != "Allow" {
+		t.Errorf("Effect = %v, want Allow", s["Effect"])
+	}
+
+	action, _ := s["Action"].([]any)
+	if len(action) != 1 || action[0] != "iam:CreateRole" {
+		t.Errorf("Action = %v, want [iam:CreateRole]", s["Action"])
+	}
+
+	resource, _ := s["Resource"].([]any)
+	if len(resource) != 1 || resource[0] != "arn:aws:iam::123456789012:role/terraform-managed/*" {
+		t.Errorf("Resource = %v, want [arn:aws:iam::123456789012:role/terraform-managed/*]", s["Resource"])
+	}
+
+	condition, _ := s["Condition"].(map[string]any)
+	stringEquals, _ := condition["StringEquals"].(map[string]any)
+
+	if stringEquals["iam:PermissionsBoundary"] != "arn:aws:iam::123456789012:policy/boundaries/TerraformWorkloadBoundary" {
+		t.Errorf("Condition.StringEquals[iam:PermissionsBoundary] = %v, want the workload boundary ARN", stringEquals["iam:PermissionsBoundary"])
+	}
+}
+
+func TestDeployBoundary_ManageTerraformRoles(t *testing.T) {
+	t.Parallel()
+
+	// Every action spec section 12.2 lists except PutRolePermissionsBoundary,
+	// to prove that one gets added even when Pike didn't separately detect it.
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{
+		"iam:AttachRolePolicy",
+		"iam:DeleteRole",
+		"iam:DeleteRolePolicy",
+		"iam:DetachRolePolicy",
+		"iam:PutRolePolicy",
+		"iam:TagRole",
+		"iam:UntagRole",
+	}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := statementBySid(t, raw, "ManageTerraformRoles")
+
+	want := []string{
+		"iam:AttachRolePolicy",
+		"iam:DeleteRole",
+		"iam:DeleteRolePolicy",
+		"iam:DetachRolePolicy",
+		"iam:PutRolePermissionsBoundary",
+		"iam:PutRolePolicy",
+		"iam:TagRole",
+		"iam:UntagRole",
+	}
+
+	action, _ := s["Action"].([]any)
+	if len(action) != len(want) {
+		t.Fatalf("Action = %v, want %v", action, want)
+	}
+
+	for i, a := range want {
+		if action[i] != a {
+			t.Errorf("Action[%d] = %v, want %q", i, action[i], a)
+		}
+	}
+
+	resource, _ := s["Resource"].([]any)
+	if len(resource) != 1 || resource[0] != "arn:aws:iam::123456789012:role/terraform-managed/*" {
+		t.Errorf("Resource = %v, want the managed-role ARN", s["Resource"])
+	}
+}
+
+func TestDeployBoundary_PassRole(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:PassRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, _ := json.Marshal(doc)
+	s := statementBySid(t, raw, "PassManagedRolesToApprovedServices")
+
+	condition, _ := s["Condition"].(map[string]any)
+	stringEquals, _ := condition["StringEquals"].(map[string]any)
+	services, _ := stringEquals["iam:PassedToService"].([]any)
+
+	if len(services) != 2 || services[0] != "ecs-tasks.amazonaws.com" || services[1] != "scheduler.amazonaws.com" {
+		t.Errorf("Condition.StringEquals[iam:PassedToService] = %v, want the two configured services sorted", services)
+	}
+}
+
+func TestDeployBoundary_PassRole_MissingAllowedServices(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:PassRole"}, Resources: []string{"*"}}}}
+
+	cfg := testConfig()
+	cfg.PassRole.AllowedServices = nil
+
+	_, err := transform.DeployBoundary(p, cfg)
+
+	var target *transform.PassRoleServicesRequiredError
+	if !errors.As(err, &target) {
+		t.Fatalf("DeployBoundary() error = %v, want *PassRoleServicesRequiredError", err)
+	}
+}
+
+func TestDeployBoundary_ServiceLinkedRole(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateServiceLinkedRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, _ := json.Marshal(doc)
+	s := statementBySid(t, raw, "CreateApprovedServiceLinkedRoles")
+
+	resource, _ := s["Resource"].([]any)
+	if len(resource) != 1 || resource[0] != "*" {
+		t.Errorf("Resource = %v, want [*]", s["Resource"])
+	}
+
+	condition, _ := s["Condition"].(map[string]any)
+	stringEquals, _ := condition["StringEquals"].(map[string]any)
+	services, _ := stringEquals["iam:AWSServiceName"].([]any)
+
+	if len(services) != 1 || services[0] != "ecs.amazonaws.com" {
+		t.Errorf("Condition.StringEquals[iam:AWSServiceName] = %v, want [ecs.amazonaws.com]", services)
+	}
+}
+
+func TestDeployBoundary_ServiceLinkedRole_MissingAllowedServices(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateServiceLinkedRole"}, Resources: []string{"*"}}}}
+
+	cfg := testConfig()
+	cfg.ServiceLinkedRoles.AllowedServices = nil
+
+	_, err := transform.DeployBoundary(p, cfg)
+
+	var target *transform.ServiceLinkedRoleServicesRequiredError
+	if !errors.As(err, &target) {
+		t.Fatalf("DeployBoundary() error = %v, want *ServiceLinkedRoleServicesRequiredError", err)
+	}
+}
+
+func TestDeployBoundary_MandatoryDeniesAlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	// Empty scanned policy: the denies must still appear, driven by
+	// config alone (spec section 12.5 / 4.2), not by what was detected.
+	doc, err := transform.DeployBoundary(policy.Policy{}, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, _ := json.Marshal(doc)
+
+	for _, tt := range []struct {
+		sid    string
+		action []string
+	}{
+		{"DenyWorkloadBoundaryRemoval", []string{"iam:DeleteRolePermissionsBoundary"}},
+		{"DenyBoundaryPolicyMutation", []string{"iam:CreatePolicyVersion", "iam:DeletePolicy", "iam:DeletePolicyVersion", "iam:SetDefaultPolicyVersion"}},
+		{"DenyOrganizationManagement", []string{"account:*", "organizations:*"}},
+	} {
+		s := statementBySid(t, raw, tt.sid)
+
+		if s["Effect"] != "Deny" {
+			t.Errorf("%s: Effect = %v, want Deny", tt.sid, s["Effect"])
+		}
+
+		action, _ := s["Action"].([]any)
+		if len(action) != len(tt.action) {
+			t.Fatalf("%s: Action = %v, want %v", tt.sid, action, tt.action)
+		}
+
+		for i, a := range tt.action {
+			if action[i] != a {
+				t.Errorf("%s: Action[%d] = %v, want %q", tt.sid, i, action[i], a)
+			}
+		}
+	}
+
+	boundaryDeny := statementBySid(t, raw, "DenyBoundaryPolicyMutation")
+	resource, _ := boundaryDeny["Resource"].([]any)
+
+	if len(resource) != 1 || resource[0] != "arn:aws:iam::123456789012:policy/boundaries/*" {
+		t.Errorf("DenyBoundaryPolicyMutation Resource = %v, want [arn:aws:iam::123456789012:policy/boundaries/*]", resource)
+	}
+}
+
+func TestDeployBoundary_MandatoryDeniesRespectSecurityFlags(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.Security.DenyOrganizationManagement = false
+
+	doc, err := transform.DeployBoundary(policy.Policy{}, cfg)
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	for _, s := range doc.Statements {
+		if s.Sid == "DenyOrganizationManagement" {
+			t.Fatal("DenyOrganizationManagement present despite security.deny_organization_management = false")
+		}
+	}
+}
+
+func TestDeployBoundary_UnknownIAMActionFailsClosedByDefault(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:UpdateRoleDescription"}, Resources: []string{"*"}}}}
+
+	_, err := transform.DeployBoundary(p, testConfig())
+
+	var target *transform.UnknownIAMActionError
+	if !errors.As(err, &target) {
+		t.Fatalf("DeployBoundary() error = %v, want *UnknownIAMActionError", err)
+	}
+}
+
+func TestDeployBoundary_UnknownIAMActionAllowedWhenFlagDisabled(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:UpdateRoleDescription"}, Resources: []string{"*"}}}}
+
+	cfg := testConfig()
+	cfg.Security.FailOnUnknownIAMAction = false
+
+	doc, err := transform.DeployBoundary(p, cfg)
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v, want nil", err)
+	}
+
+	for _, s := range doc.Statements {
+		for _, a := range s.Action {
+			if a == "iam:UpdateRoleDescription" {
+				t.Fatalf("unclassified action leaked into statement %q — it must be dropped, not silently allowed", s.Sid)
+			}
+		}
+	}
+}
+
+func TestDeployBoundary_NonIAMActionsPassThrough(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"ec2:RunInstances", "ec2:DescribeInstances"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	var found []string
+
+	for _, s := range doc.Statements {
+		if s.Effect == "Allow" {
+			found = append(found, s.Action...)
+		}
+	}
+
+	for _, want := range []string{"ec2:RunInstances", "ec2:DescribeInstances"} {
+		ok := false
+
+		for _, a := range found {
+			if a == want {
+				ok = true
+
+				break
+			}
+		}
+
+		if !ok {
+			t.Errorf("non-IAM action %q missing from the boundary", want)
+		}
+	}
+}
+
+func TestDeployBoundary_CreateRoleNeverUnconditional(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	for _, s := range doc.Statements {
+		for _, a := range s.Action {
+			if a == "iam:CreateRole" && s.Condition == nil {
+				t.Fatal("an iam:CreateRole statement has no Condition — spec section 12.1: this must never remain unconditional")
+			}
+		}
+	}
+}
+
+func TestDeployBoundary_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{
+		{Actions: []string{"iam:CreateRole", "iam:PassRole", "iam:CreateServiceLinkedRole", "iam:GetRole"}, Resources: []string{"*"}},
+		{Actions: []string{"s3:GetObject", "s3:PutObject"}, Resources: []string{"*"}},
+	}}
+
+	cfg := testConfig()
+
+	first, err := transform.DeployBoundary(p, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		doc, err := transform.DeployBoundary(p, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := json.Marshal(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(got) != string(firstJSON) {
+			t.Fatalf("run %d: DeployBoundary() rendered differently:\n%s\nvs\n%s", i, got, firstJSON)
+		}
+	}
+}
+
+func TestDeployBoundary_NonIAMDeduplicatesWithinAStatement(t *testing.T) {
+	t.Parallel()
+
+	// Pike's real scan output repeats an action within a statement when
+	// multiple attributes on one resource all require it (e.g.
+	// aws_ecs_task_definition's execution_role_arn and task_role_arn
+	// attributes both require ecs:DescribeTaskDefinition-adjacent calls).
+	p := policy.Policy{Statements: []policy.Statement{{
+		Actions:   []string{"ecs:DescribeTaskDefinition", "ecs:RegisterTaskDefinition", "ecs:DescribeTaskDefinition"},
+		Resources: []string{"*", "*"},
+	}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	var nonIAM []string
+
+	for _, s := range doc.Statements {
+		if s.Sid == "NonIAM0" {
+			nonIAM = s.Action
+		}
+	}
+
+	want := []string{"ecs:DescribeTaskDefinition", "ecs:RegisterTaskDefinition"}
+	if len(nonIAM) != len(want) {
+		t.Fatalf("NonIAM0 Action = %v, want %v (deduplicated)", nonIAM, want)
+	}
+
+	for i, a := range want {
+		if nonIAM[i] != a {
+			t.Errorf("NonIAM0 Action[%d] = %q, want %q", i, nonIAM[i], a)
+		}
+	}
+}

--- a/internal/bootstrap/transform/deploy_boundary_test.go
+++ b/internal/bootstrap/transform/deploy_boundary_test.go
@@ -113,13 +113,16 @@ func TestDeployBoundary_CreateRole(t *testing.T) {
 func TestDeployBoundary_ManageTerraformRoles(t *testing.T) {
 	t.Parallel()
 
-	// Every action spec section 12.2 lists except PutRolePermissionsBoundary,
-	// to prove that one gets added even when Pike didn't separately detect it.
+	// Every action spec section 12.2 lists, plus PutRolePermissionsBoundary
+	// to prove that one is excluded from this statement even when Pike
+	// detects it directly - it always gets its own conditioned statement
+	// instead (TestDeployBoundary_MaintainRequiredBoundary).
 	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{
 		"iam:AttachRolePolicy",
 		"iam:DeleteRole",
 		"iam:DeleteRolePolicy",
 		"iam:DetachRolePolicy",
+		"iam:PutRolePermissionsBoundary",
 		"iam:PutRolePolicy",
 		"iam:TagRole",
 		"iam:UntagRole",
@@ -142,7 +145,6 @@ func TestDeployBoundary_ManageTerraformRoles(t *testing.T) {
 		"iam:DeleteRole",
 		"iam:DeleteRolePolicy",
 		"iam:DetachRolePolicy",
-		"iam:PutRolePermissionsBoundary",
 		"iam:PutRolePolicy",
 		"iam:TagRole",
 		"iam:UntagRole",
@@ -159,9 +161,71 @@ func TestDeployBoundary_ManageTerraformRoles(t *testing.T) {
 		}
 	}
 
+	for _, a := range action {
+		if a == "iam:PutRolePermissionsBoundary" {
+			t.Errorf("ManageTerraformRoles.Action contains iam:PutRolePermissionsBoundary, want it excluded (unconditioned boundary-swap risk)")
+		}
+	}
+
 	resource, _ := s["Resource"].([]any)
 	if len(resource) != 1 || resource[0] != "arn:aws:iam::123456789012:role/terraform-managed/*" {
 		t.Errorf("Resource = %v, want the managed-role ARN", s["Resource"])
+	}
+}
+
+func TestDeployBoundary_MaintainRequiredBoundary(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:PutRolePolicy"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, _ := json.Marshal(doc)
+	s := statementBySid(t, raw, "MaintainRequiredBoundary")
+
+	action, _ := s["Action"].([]any)
+	if len(action) != 1 || action[0] != "iam:PutRolePermissionsBoundary" {
+		t.Errorf("Action = %v, want [iam:PutRolePermissionsBoundary]", s["Action"])
+	}
+
+	resource, _ := s["Resource"].([]any)
+	if len(resource) != 1 || resource[0] != "arn:aws:iam::123456789012:role/terraform-managed/*" {
+		t.Errorf("Resource = %v, want the managed-role ARN", s["Resource"])
+	}
+
+	condition, _ := s["Condition"].(map[string]any)
+	stringEquals, _ := condition["StringEquals"].(map[string]any)
+
+	if stringEquals["iam:PermissionsBoundary"] != "arn:aws:iam::123456789012:policy/boundaries/TerraformWorkloadBoundary" {
+		t.Errorf("Condition.StringEquals[iam:PermissionsBoundary] = %v, want the workload boundary ARN", stringEquals["iam:PermissionsBoundary"])
+	}
+}
+
+// TestDeployBoundary_MaintainRequiredBoundary_PresentOnRoleCreateAlone
+// confirms the statement appears even when only iam:CreateRole was
+// detected, with no other role-policy-write actions - the exact case the
+// original unconditioned-PutRolePermissionsBoundary bug slipped through in,
+// since that case still legitimately needs to (re)apply the boundary.
+func TestDeployBoundary_MaintainRequiredBoundary_PresentOnRoleCreateAlone(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	raw, _ := json.Marshal(doc)
+	_ = statementBySid(t, raw, "MaintainRequiredBoundary")
+
+	for _, s := range doc.Statements {
+		if s.Sid == "ManageTerraformRoles" {
+			t.Errorf("ManageTerraformRoles present with no role-policy-write actions detected: %+v", s)
+		}
 	}
 }
 

--- a/internal/bootstrap/transform/privesc_test.go
+++ b/internal/bootstrap/transform/privesc_test.go
@@ -1,0 +1,307 @@
+package transform_test
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/transform"
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+// This file simulates specific attempted IAM privilege-escalation calls
+// against a generated deploy-boundary.json and asserts the whole document
+// (Allow and Deny statements together, with explicit-deny-wins evaluation)
+// actually blocks them - rather than checking that a particular action
+// string is merely present or absent in one statement, which is what let
+// the original iam:PutRolePermissionsBoundary bug go unnoticed.
+
+// simulatedRequest is a minimal stand-in for an AWS API call: the action
+// and resource being requested, and the condition-key/value context that
+// would be present on the real request (e.g. iam:PermissionsBoundary is
+// only present on calls that set a boundary).
+type simulatedRequest struct {
+	action   string
+	resource string
+	context  map[string]string
+}
+
+// evaluateAllowed mimics AWS IAM policy evaluation order: an explicit Deny
+// in any applicable statement always wins, regardless of any Allow
+// elsewhere in the document; otherwise the request is allowed only if at
+// least one Allow statement applies; everything else is an implicit deny.
+func evaluateAllowed(doc render.Document, req simulatedRequest) bool {
+	allowed := false
+
+	for _, s := range doc.Statements {
+		if !statementApplies(s, req) {
+			continue
+		}
+
+		if s.Effect == "Deny" {
+			return false
+		}
+
+		allowed = true
+	}
+
+	return allowed
+}
+
+func statementApplies(s render.Statement, req simulatedRequest) bool {
+	if !containsAction(s.Action, req.action) {
+		return false
+	}
+
+	if !matchesAny(s.Resource, req.resource) {
+		return false
+	}
+
+	return conditionSatisfied(s.Condition, req.context)
+}
+
+func containsAction(actions []string, action string) bool {
+	return slices.Contains(actions, action)
+}
+
+func matchesAny(patterns []string, resource string) bool {
+	return slices.ContainsFunc(patterns, func(p string) bool {
+		return matchesARNPattern(p, resource)
+	})
+}
+
+// matchesARNPattern treats "*" as a glob wildcard, the only wildcard usage
+// this generator ever produces (trailing-* role/policy paths, or a bare
+// "*").
+func matchesARNPattern(pattern, resource string) bool {
+	quoted := regexp.QuoteMeta(pattern)
+	re := "^" + strings.ReplaceAll(quoted, `\*`, ".*") + "$"
+
+	matched, err := regexp.MatchString(re, resource)
+	if err != nil {
+		return false
+	}
+
+	return matched
+}
+
+// conditionSatisfied evaluates a StringEquals condition against the
+// request context the way AWS does: every key in the condition must be
+// present in the request context and match, and a nil Condition always
+// matches (the statement is unconditional).
+func conditionSatisfied(cond *render.Condition, ctx map[string]string) bool {
+	if cond == nil || cond.StringEquals == nil {
+		return true
+	}
+
+	for key, want := range cond.StringEquals {
+		got, present := ctx[key]
+		if !present {
+			return false
+		}
+
+		if !valueMatches(want, got) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func valueMatches(want any, got string) bool {
+	switch v := want.(type) {
+	case string:
+		return v == got
+	case []string:
+		return slices.Contains(v, got)
+	default:
+		return false
+	}
+}
+
+const (
+	managedRoleWildcard           = "arn:aws:iam::123456789012:role/terraform-managed/*"
+	someManagedRole               = "arn:aws:iam::123456789012:role/terraform-managed/some-app-role"
+	requiredWorkloadBoundaryARN   = "arn:aws:iam::123456789012:policy/boundaries/TerraformWorkloadBoundary"
+	attackerControlledBoundaryARN = "arn:aws:iam::123456789012:policy/boundaries/AttackerControlledPermissive"
+)
+
+// TestPrivesc_BoundarySwapBlocked simulates the exact escalation the
+// original bug allowed: the deploy role calling PutRolePermissionsBoundary
+// on a role it manages, but pointing it at a different, attacker-controlled
+// boundary policy instead of the required workload boundary. A generated
+// policy that lets this succeed defeats the entire purpose of
+// CreateRoleWithRequiredBoundary - the created role's boundary can just be
+// swapped out afterwards.
+func TestPrivesc_BoundarySwapBlocked(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	req := simulatedRequest{
+		action:   "iam:PutRolePermissionsBoundary",
+		resource: someManagedRole,
+		context:  map[string]string{"iam:PermissionsBoundary": attackerControlledBoundaryARN},
+	}
+
+	if evaluateAllowed(doc, req) {
+		t.Fatal("boundary-swap escalation succeeded: the deploy role could re-point a managed role at an attacker-controlled permissions boundary")
+	}
+}
+
+// TestPrivesc_BoundarySwap_MethodologyCatchesTheOriginalBug is a
+// calibration test: it hand-builds the exact statement shape the original
+// (pre-fix) fork produced - PutRolePermissionsBoundary bundled into
+// ManageTerraformRoles with no Condition - and confirms evaluateAllowed
+// correctly flags it as exploitable. This proves the simulator above isn't
+// vacuously passing; it would have caught the real bug had it existed when
+// the bug did.
+func TestPrivesc_BoundarySwap_MethodologyCatchesTheOriginalBug(t *testing.T) {
+	t.Parallel()
+
+	vulnerableDoc := render.Document{
+		Version: "2012-10-17",
+		Statements: []render.Statement{
+			{
+				Sid:      "ManageTerraformRoles",
+				Effect:   "Allow",
+				Action:   []string{"iam:PutRolePermissionsBoundary", "iam:PutRolePolicy"},
+				Resource: []string{managedRoleWildcard},
+				// No Condition - this is the original bug's shape.
+			},
+		},
+	}
+
+	req := simulatedRequest{
+		action:   "iam:PutRolePermissionsBoundary",
+		resource: someManagedRole,
+		context:  map[string]string{"iam:PermissionsBoundary": attackerControlledBoundaryARN},
+	}
+
+	if !evaluateAllowed(vulnerableDoc, req) {
+		t.Fatal("evaluateAllowed did not flag the known-vulnerable unconditioned statement shape as exploitable - the simulator itself is broken")
+	}
+}
+
+// TestPrivesc_LegitimateBoundaryMaintenanceStillWorks confirms the fix
+// didn't just block everything: reapplying the *required* boundary (e.g.
+// Terraform correcting drift on an existing managed role) must still
+// succeed.
+func TestPrivesc_LegitimateBoundaryMaintenanceStillWorks(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:CreateRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	req := simulatedRequest{
+		action:   "iam:PutRolePermissionsBoundary",
+		resource: someManagedRole,
+		context:  map[string]string{"iam:PermissionsBoundary": requiredWorkloadBoundaryARN},
+	}
+
+	if !evaluateAllowed(doc, req) {
+		t.Fatal("legitimate boundary maintenance (reapplying the required workload boundary) was blocked - the fix over-corrected")
+	}
+}
+
+// TestPrivesc_PassRoleToUnapprovedServiceBlocked simulates the classic
+// PassRole escalation: pass a managed role to a service the deploy role
+// can also provision compute in (e.g. Lambda), then run code as that role.
+// pass_role.allowed_services in testConfig() only allows ECS services, so
+// passing to Lambda must fail.
+func TestPrivesc_PassRoleToUnapprovedServiceBlocked(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:PassRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	req := simulatedRequest{
+		action:   "iam:PassRole",
+		resource: someManagedRole,
+		context:  map[string]string{"iam:PassedToService": "lambda.amazonaws.com"},
+	}
+
+	if evaluateAllowed(doc, req) {
+		t.Fatal("iam:PassRole succeeded against an unapproved service (lambda.amazonaws.com) - pass_role.allowed_services was not enforced")
+	}
+}
+
+// TestPrivesc_PassRoleToApprovedServiceStillWorks is the sanity check for
+// the test above: passing to a service that *is* on the allow-list must
+// still succeed.
+func TestPrivesc_PassRoleToApprovedServiceStillWorks(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{Statements: []policy.Statement{{Actions: []string{"iam:PassRole"}, Resources: []string{"*"}}}}
+
+	doc, err := transform.DeployBoundary(p, testConfig())
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	req := simulatedRequest{
+		action:   "iam:PassRole",
+		resource: someManagedRole,
+		context:  map[string]string{"iam:PassedToService": "ecs-tasks.amazonaws.com"},
+	}
+
+	if !evaluateAllowed(doc, req) {
+		t.Fatal("iam:PassRole was blocked even for an approved service (ecs-tasks.amazonaws.com)")
+	}
+}
+
+// TestPrivesc_BoundaryPolicyContentMutationDeniedAcrossBothPaths locks in
+// the DenyBoundaryPolicyMutation hardening: deploy_boundary and
+// workload_boundary are allowed to live under different IAM paths
+// (config.Validate doesn't require them to match each other), and the
+// deny must cover both - not just deploy_boundary's, which was the
+// original scope. No current statement actually grants
+// iam:CreatePolicyVersion (PolicyMutation-classified actions are never
+// wired into an Allow), so this test injects a hypothetical Allow to prove
+// the Deny would still win via explicit-deny-always-wins evaluation if
+// that ever changed.
+func TestPrivesc_BoundaryPolicyContentMutationDeniedAcrossBothPaths(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.Policies.DeployBoundary.Path = "/deploy-boundaries/"
+	cfg.Policies.WorkloadBoundary.Path = "/workload-boundaries/"
+
+	doc, err := transform.DeployBoundary(policy.Policy{}, cfg)
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	workloadBoundaryPolicyARN := "arn:aws:iam::123456789012:policy/workload-boundaries/TerraformWorkloadBoundary"
+
+	doc.Statements = append(doc.Statements, render.Statement{
+		Sid:      "HypotheticalGrant",
+		Effect:   "Allow",
+		Action:   []string{"iam:CreatePolicyVersion"},
+		Resource: []string{workloadBoundaryPolicyARN},
+	})
+
+	req := simulatedRequest{
+		action:   "iam:CreatePolicyVersion",
+		resource: workloadBoundaryPolicyARN,
+	}
+
+	if evaluateAllowed(doc, req) {
+		t.Fatal("iam:CreatePolicyVersion on the workload boundary policy succeeded - DenyBoundaryPolicyMutation doesn't cover workload_boundary's path")
+	}
+}

--- a/internal/bootstrap/validate/validate.go
+++ b/internal/bootstrap/validate/validate.go
@@ -1,0 +1,351 @@
+// Package validate checks generated bootstrap artifacts against the
+// blocking and warning rules in spec section 17. It runs as a defense-in-
+// depth pass over the rendered documents themselves — deploy-boundary
+// transformation (internal/bootstrap/transform) already enforces most of
+// these invariants by construction, but validating the artifact
+// independently also catches artifacts that were hand-edited after
+// generation, and is what the future `pike bootstrap validate` CLI
+// command will run against files already on disk.
+//
+// RMP-E010, RMP-E011 and RMP-E012 are not implemented here: they need
+// live AWS state (a managed-path role audit, the caller's STS identity)
+// that only exists once the inspect/apply milestone (M3/M4) is built.
+// Likewise, most of section 17.2's warnings need infrastructure this
+// package doesn't have yet (Pike mapping metadata, existing live AWS
+// policy content) — only the workload-allowlist-wildcard warning is
+// checkable from config alone, so it's the only one implemented so far.
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/classify"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+)
+
+// Severity distinguishes findings that must block generation from ones
+// that are informational only (spec sections 17.1 vs 17.2).
+type Severity string
+
+const (
+	Blocking Severity = "blocking"
+	Warning  Severity = "warning"
+)
+
+// Finding is a single validation result.
+type Finding struct {
+	Code     string
+	Severity Severity
+	Message  string
+}
+
+// Artifacts bundles the generated documents this package's rules check.
+type Artifacts struct {
+	DeployBoundary   render.Document
+	TrustPolicy      render.TrustDocument
+	AssumeRolePolicy render.Document
+}
+
+// Validate runs every rule in this package against a generated bootstrap
+// package and its config, returning every finding (not just the first).
+func Validate(a Artifacts, cfg *config.Config) []Finding {
+	var findings []Finding
+
+	findings = append(findings, checkCreateRoleConditioned(a.DeployBoundary, cfg)...)
+	findings = append(findings, checkPassRole(a.DeployBoundary, cfg)...)
+	findings = append(findings, checkServiceLinkedRole(a.DeployBoundary)...)
+	findings = append(findings, checkBoundaryDenies(a.DeployBoundary)...)
+	findings = append(findings, checkUnclassifiedActions(a.DeployBoundary)...)
+	findings = append(findings, checkTrustPolicyMFA(a.TrustPolicy)...)
+	findings = append(findings, checkAssumeRolePolicyMinimal(a.AssumeRolePolicy)...)
+	findings = append(findings, checkWorkloadAllowlistWildcard(cfg)...)
+
+	return findings
+}
+
+// checkCreateRoleConditioned covers RMP-E001 (unconditional CreateRole)
+// and RMP-E002 (condition present but not the exact expected boundary).
+func checkCreateRoleConditioned(doc render.Document, cfg *config.Config) []Finding {
+	var findings []Finding
+
+	expectedBoundaryARN := namedPolicyARN(cfg, cfg.Policies.WorkloadBoundary.Path, cfg.Policies.WorkloadBoundary.Name)
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" || !containsAction(s.Action, "iam:CreateRole") {
+			continue
+		}
+
+		if s.Condition == nil {
+			findings = append(findings, Finding{
+				Code:     "RMP-E001",
+				Severity: Blocking,
+				Message:  "iam:CreateRole is allowed without any Condition",
+			})
+
+			continue
+		}
+
+		got := conditionString(s.Condition, "iam:PermissionsBoundary")
+		if got != expectedBoundaryARN {
+			findings = append(findings, Finding{
+				Code:     "RMP-E002",
+				Severity: Blocking,
+				Message:  fmt.Sprintf("iam:CreateRole Condition.StringEquals[iam:PermissionsBoundary] = %q, want %q", got, expectedBoundaryARN),
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkPassRole covers RMP-E003 (Resource "*" or outside the managed-role
+// path) and RMP-E004 (missing PassedToService restriction).
+func checkPassRole(doc render.Document, cfg *config.Config) []Finding {
+	var findings []Finding
+
+	managedPrefix := strings.TrimSuffix(roleARN(cfg, cfg.ManagedRoles.Path), "*")
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" || !containsAction(s.Action, "iam:PassRole") {
+			continue
+		}
+
+		for _, r := range s.Resource {
+			if r == "*" || !strings.HasPrefix(r, managedPrefix) {
+				findings = append(findings, Finding{
+					Code:     "RMP-E003",
+					Severity: Blocking,
+					Message:  fmt.Sprintf("iam:PassRole Resource %q is \"*\" or escapes the managed-role path", r),
+				})
+			}
+		}
+
+		if len(conditionStringList(s.Condition, "iam:PassedToService")) == 0 {
+			findings = append(findings, Finding{
+				Code:     "RMP-E004",
+				Severity: Blocking,
+				Message:  "iam:PassRole is missing a Condition.StringEquals[iam:PassedToService] restriction",
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkServiceLinkedRole covers RMP-E005.
+func checkServiceLinkedRole(doc render.Document) []Finding {
+	var findings []Finding
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" || !containsAction(s.Action, "iam:CreateServiceLinkedRole") {
+			continue
+		}
+
+		if len(conditionStringList(s.Condition, "iam:AWSServiceName")) == 0 {
+			findings = append(findings, Finding{
+				Code:     "RMP-E005",
+				Severity: Blocking,
+				Message:  "iam:CreateServiceLinkedRole is missing a Condition.StringEquals[iam:AWSServiceName] restriction",
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkBoundaryDenies covers RMP-E006: boundary removal and boundary-
+// policy mutation must each have an explicit Deny.
+func checkBoundaryDenies(doc render.Document) []Finding {
+	var findings []Finding
+
+	if !hasDenyFor(doc, "iam:DeleteRolePermissionsBoundary") {
+		findings = append(findings, Finding{
+			Code:     "RMP-E006",
+			Severity: Blocking,
+			Message:  "no explicit Deny for iam:DeleteRolePermissionsBoundary (boundary removal)",
+		})
+	}
+
+	for _, action := range []string{"iam:CreatePolicyVersion", "iam:DeletePolicyVersion", "iam:SetDefaultPolicyVersion", "iam:DeletePolicy"} {
+		if !hasDenyFor(doc, action) {
+			findings = append(findings, Finding{
+				Code:     "RMP-E006",
+				Severity: Blocking,
+				Message:  fmt.Sprintf("no explicit Deny for %s (boundary-policy mutation)", action),
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkUnclassifiedActions covers RMP-E007: every Allow'd IAM/STS action
+// must be something the classifier recognizes.
+func checkUnclassifiedActions(doc render.Document) []Finding {
+	var findings []Finding
+
+	seen := make(map[string]bool)
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" {
+			continue
+		}
+
+		for _, action := range s.Action {
+			if seen[action] || !isIAMOrSTS(action) {
+				continue
+			}
+
+			seen[action] = true
+
+			if classify.Classify(action) == classify.Unknown {
+				findings = append(findings, Finding{
+					Code:     "RMP-E007",
+					Severity: Blocking,
+					Message:  fmt.Sprintf("unclassified IAM/STS action %q is allowed in the deploy boundary", action),
+				})
+			}
+		}
+	}
+
+	return findings
+}
+
+// checkTrustPolicyMFA covers RMP-E008.
+func checkTrustPolicyMFA(doc render.TrustDocument) []Finding {
+	var findings []Finding
+
+	for _, s := range doc.Statement {
+		if s.Effect != "Allow" || s.Action != "sts:AssumeRole" {
+			continue
+		}
+
+		if s.Condition == nil || s.Condition.Bool["aws:MultiFactorAuthPresent"] != "true" {
+			findings = append(findings, Finding{
+				Code:     "RMP-E008",
+				Severity: Blocking,
+				Message:  "trust policy allows sts:AssumeRole without requiring aws:MultiFactorAuthPresent",
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkAssumeRolePolicyMinimal covers RMP-E009: the source-principal
+// policy must grant only sts:AssumeRole.
+func checkAssumeRolePolicyMinimal(doc render.Document) []Finding {
+	var findings []Finding
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" {
+			continue
+		}
+
+		for _, action := range s.Action {
+			if action != "sts:AssumeRole" {
+				findings = append(findings, Finding{
+					Code:     "RMP-E009",
+					Severity: Blocking,
+					Message:  fmt.Sprintf("source-principal policy grants %q, want only sts:AssumeRole", action),
+				})
+			}
+		}
+	}
+
+	return findings
+}
+
+// checkWorkloadAllowlistWildcard covers the section 17.2 warning: a
+// service wildcard (e.g. "s3:*") in the workload allowlist isn't blocked
+// by config validation (only the specific IAM/STS/org/account wildcards
+// are, per section 7.1) but is worth flagging.
+func checkWorkloadAllowlistWildcard(cfg *config.Config) []Finding {
+	var findings []Finding
+
+	for _, action := range cfg.Policies.WorkloadBoundary.AllowedActions {
+		if strings.HasSuffix(action, ":*") {
+			findings = append(findings, Finding{
+				Code:     "WORKLOAD_ALLOWLIST_WILDCARD",
+				Severity: Warning,
+				Message:  fmt.Sprintf("policies.workload_boundary.allowed_actions contains a service wildcard %q", action),
+			})
+		}
+	}
+
+	return findings
+}
+
+func hasDenyFor(doc render.Document, action string) bool {
+	for _, s := range doc.Statements {
+		if s.Effect == "Deny" && containsAction(s.Action, action) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsAction(actions []string, action string) bool {
+	for _, a := range actions {
+		if a == action {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isIAMOrSTS(action string) bool {
+	return strings.HasPrefix(action, "iam:") || strings.HasPrefix(action, "sts:")
+}
+
+// conditionString and conditionStringList tolerate both a Go []string
+// (the shape transform.DeployBoundary builds in memory) and the []any a
+// fresh json.Unmarshal into map[string]any produces (the shape this
+// package will see once artifacts are validated from disk), so this
+// package works for either caller.
+func conditionString(cond *render.Condition, key string) string {
+	if cond == nil || cond.StringEquals == nil {
+		return ""
+	}
+
+	s, _ := cond.StringEquals[key].(string)
+
+	return s
+}
+
+func conditionStringList(cond *render.Condition, key string) []string {
+	if cond == nil || cond.StringEquals == nil {
+		return nil
+	}
+
+	switch v := cond.StringEquals[key].(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+
+		return out
+	case string:
+		return []string{v}
+	default:
+		return nil
+	}
+}
+
+func roleARN(cfg *config.Config, path string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:role%s*", cfg.AWS.Partition, cfg.AWS.AccountID, path)
+}
+
+func namedPolicyARN(cfg *config.Config, path, name string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:policy%s%s", cfg.AWS.Partition, cfg.AWS.AccountID, path, name)
+}

--- a/internal/bootstrap/validate/validate.go
+++ b/internal/bootstrap/validate/validate.go
@@ -18,6 +18,7 @@ package validate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/jameswoolfenden/pike/internal/bootstrap/classify"
@@ -54,6 +55,7 @@ func Validate(a Artifacts, cfg *config.Config) []Finding {
 	var findings []Finding
 
 	findings = append(findings, checkCreateRoleConditioned(a.DeployBoundary, cfg)...)
+	findings = append(findings, checkPutRolePermissionsBoundaryConditioned(a.DeployBoundary, cfg)...)
 	findings = append(findings, checkPassRole(a.DeployBoundary, cfg)...)
 	findings = append(findings, checkServiceLinkedRole(a.DeployBoundary)...)
 	findings = append(findings, checkBoundaryDenies(a.DeployBoundary)...)
@@ -93,6 +95,46 @@ func checkCreateRoleConditioned(doc render.Document, cfg *config.Config) []Findi
 				Code:     "RMP-E002",
 				Severity: Blocking,
 				Message:  fmt.Sprintf("iam:CreateRole Condition.StringEquals[iam:PermissionsBoundary] = %q, want %q", got, expectedBoundaryARN),
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkPutRolePermissionsBoundaryConditioned covers RMP-E013 (unconditional
+// iam:PutRolePermissionsBoundary) and RMP-E014 (condition present but not
+// the exact expected boundary). An unconditioned or wrongly-scoped grant of
+// this action lets the deploy role re-point a managed role at a different,
+// more permissive boundary policy, bypassing CreateRole's own boundary
+// condition and the boundary-tampering denies entirely - the class of bug
+// that motivated this rule.
+func checkPutRolePermissionsBoundaryConditioned(doc render.Document, cfg *config.Config) []Finding {
+	var findings []Finding
+
+	expectedBoundaryARN := namedPolicyARN(cfg, cfg.Policies.WorkloadBoundary.Path, cfg.Policies.WorkloadBoundary.Name)
+
+	for _, s := range doc.Statements {
+		if s.Effect != "Allow" || !containsAction(s.Action, "iam:PutRolePermissionsBoundary") {
+			continue
+		}
+
+		if s.Condition == nil {
+			findings = append(findings, Finding{
+				Code:     "RMP-E013",
+				Severity: Blocking,
+				Message:  "iam:PutRolePermissionsBoundary is allowed without any Condition",
+			})
+
+			continue
+		}
+
+		got := conditionString(s.Condition, "iam:PermissionsBoundary")
+		if got != expectedBoundaryARN {
+			findings = append(findings, Finding{
+				Code:     "RMP-E014",
+				Severity: Blocking,
+				Message:  fmt.Sprintf("iam:PutRolePermissionsBoundary Condition.StringEquals[iam:PermissionsBoundary] = %q, want %q", got, expectedBoundaryARN),
 			})
 		}
 	}
@@ -289,13 +331,7 @@ func hasDenyFor(doc render.Document, action string) bool {
 }
 
 func containsAction(actions []string, action string) bool {
-	for _, a := range actions {
-		if a == action {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(actions, action)
 }
 
 func isIAMOrSTS(action string) bool {

--- a/internal/bootstrap/validate/validate_test.go
+++ b/internal/bootstrap/validate/validate_test.go
@@ -1,0 +1,300 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/bootstrap/config"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/render"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/transform"
+	"github.com/jameswoolfenden/pike/internal/bootstrap/validate"
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{
+		AWS: config.AWSConfig{AccountID: "123456789012", Partition: "aws"},
+		Principal: config.PrincipalConfig{
+			Type: "iam-user",
+			Name: "cli-user",
+			MFA:  config.MFAConfig{Required: true, MaxAgeSeconds: 3600},
+		},
+		DeployRole:   config.DeployRoleConfig{Name: "TerraformDeployRole", Path: "/terraform-deploy/"},
+		ManagedRoles: config.ManagedRolesConfig{Path: "/terraform-managed/"},
+		Policies: config.PoliciesConfig{
+			DeployBoundary: config.PolicyConfig{Path: "/boundaries/"},
+			WorkloadBoundary: config.WorkloadBoundaryConfig{
+				Name:           "TerraformWorkloadBoundary",
+				Path:           "/boundaries/",
+				Mode:           "allowlist",
+				AllowedActions: []string{"logs:PutLogEvents"},
+			},
+		},
+		PassRole:           config.PassRoleConfig{AllowedServices: []string{"ecs-tasks.amazonaws.com"}},
+		ServiceLinkedRoles: config.ServiceLinkedRolesConfig{AllowedServices: []string{"ecs.amazonaws.com"}},
+		Security: config.SecurityConfig{
+			FailOnUnknownIAMAction:       true,
+			DenyBoundaryRemoval:          true,
+			DenyBoundaryPolicyMutation:   true,
+			DenyHumanPrincipalManagement: true,
+			DenyAccessKeyManagement:      true,
+			DenyOrganizationManagement:   true,
+		},
+	}
+}
+
+// validArtifacts builds a full, correctly-generated set of artifacts
+// using the real transform/render code, so the "everything passes"
+// baseline is exercised the same way a real generate run would produce
+// it, not hand-crafted to trivially satisfy the checks.
+func validArtifacts(t *testing.T, cfg *config.Config) validate.Artifacts {
+	t.Helper()
+
+	p := policy.Policy{Statements: []policy.Statement{{
+		Actions: []string{
+			"iam:CreateRole", "iam:PutRolePolicy", "iam:PassRole",
+			"iam:CreateServiceLinkedRole", "iam:GetRole",
+		},
+		Resources: []string{"*"},
+	}}}
+
+	boundary, err := transform.DeployBoundary(p, cfg)
+	if err != nil {
+		t.Fatalf("DeployBoundary() error = %v", err)
+	}
+
+	trust, err := render.TrustPolicy(cfg)
+	if err != nil {
+		t.Fatalf("TrustPolicy() error = %v", err)
+	}
+
+	return validate.Artifacts{
+		DeployBoundary:   boundary,
+		TrustPolicy:      trust,
+		AssumeRolePolicy: render.AssumeRolePolicy(cfg),
+	}
+}
+
+func TestValidate_ValidArtifactsHaveNoBlockingFindings(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	findings := validate.Validate(validArtifacts(t, cfg), cfg)
+
+	for _, f := range findings {
+		if f.Severity == validate.Blocking {
+			t.Errorf("unexpected blocking finding on a validly generated artifact set: %+v", f)
+		}
+	}
+}
+
+func codes(findings []validate.Finding) []string {
+	out := make([]string, len(findings))
+	for i, f := range findings {
+		out[i] = f.Code
+	}
+
+	return out
+}
+
+func containsCode(findings []validate.Finding, code string) bool {
+	for _, f := range findings {
+		if f.Code == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestValidate_RMP_E001_UnconditionalCreateRole(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	for i, s := range a.DeployBoundary.Statements {
+		if containsActionForTest(s.Action, "iam:CreateRole") {
+			a.DeployBoundary.Statements[i].Condition = nil
+		}
+	}
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E001") {
+		t.Errorf("Validate() = %v, want RMP-E001", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E002_WrongBoundaryCondition(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	for i, s := range a.DeployBoundary.Statements {
+		if containsActionForTest(s.Action, "iam:CreateRole") {
+			a.DeployBoundary.Statements[i].Condition = &render.Condition{
+				StringEquals: map[string]any{"iam:PermissionsBoundary": "arn:aws:iam::999999999999:policy/wrong/Boundary"},
+			}
+		}
+	}
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E002") {
+		t.Errorf("Validate() = %v, want RMP-E002", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E003_PassRoleWildcardResource(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	for i, s := range a.DeployBoundary.Statements {
+		if containsActionForTest(s.Action, "iam:PassRole") {
+			a.DeployBoundary.Statements[i].Resource = []string{"*"}
+		}
+	}
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E003") {
+		t.Errorf("Validate() = %v, want RMP-E003", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E004_PassRoleMissingCondition(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	for i, s := range a.DeployBoundary.Statements {
+		if containsActionForTest(s.Action, "iam:PassRole") {
+			a.DeployBoundary.Statements[i].Condition = nil
+		}
+	}
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E004") {
+		t.Errorf("Validate() = %v, want RMP-E004", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E005_ServiceLinkedRoleMissingCondition(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	for i, s := range a.DeployBoundary.Statements {
+		if containsActionForTest(s.Action, "iam:CreateServiceLinkedRole") {
+			a.DeployBoundary.Statements[i].Condition = nil
+		}
+	}
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E005") {
+		t.Errorf("Validate() = %v, want RMP-E005", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E006_MissingBoundaryDenies(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	var kept []render.Statement
+
+	for _, s := range a.DeployBoundary.Statements {
+		if s.Effect == "Deny" {
+			continue
+		}
+
+		kept = append(kept, s)
+	}
+
+	a.DeployBoundary.Statements = kept
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E006") {
+		t.Errorf("Validate() = %v, want RMP-E006", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E007_UnclassifiedAction(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+
+	a.DeployBoundary.Statements = append(a.DeployBoundary.Statements, render.Statement{
+		Sid: "Hand-edited", Effect: "Allow", Action: []string{"iam:UpdateRoleDescription"}, Resource: []string{"*"},
+	})
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E007") {
+		t.Errorf("Validate() = %v, want RMP-E007", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E008_TrustPolicyMissingMFA(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+	a.TrustPolicy.Statement[0].Condition = nil
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E008") {
+		t.Errorf("Validate() = %v, want RMP-E008", codes(findings))
+	}
+}
+
+func TestValidate_RMP_E009_AssumeRolePolicyTooBroad(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	a := validArtifacts(t, cfg)
+	a.AssumeRolePolicy.Statements[0].Action = append(a.AssumeRolePolicy.Statements[0].Action, "iam:PassRole")
+
+	findings := validate.Validate(a, cfg)
+	if !containsCode(findings, "RMP-E009") {
+		t.Errorf("Validate() = %v, want RMP-E009", codes(findings))
+	}
+}
+
+func TestValidate_WorkloadAllowlistWildcardWarning(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.Policies.WorkloadBoundary.AllowedActions = []string{"s3:*"}
+
+	findings := validate.Validate(validArtifacts(t, cfg), cfg)
+
+	found := false
+
+	for _, f := range findings {
+		if f.Code == "WORKLOAD_ALLOWLIST_WILDCARD" {
+			found = true
+
+			if f.Severity != validate.Warning {
+				t.Errorf("Severity = %v, want Warning", f.Severity)
+			}
+		}
+	}
+
+	if !found {
+		t.Errorf("Validate() = %v, want WORKLOAD_ALLOWLIST_WILDCARD", codes(findings))
+	}
+}
+
+func containsActionForTest(actions []string, action string) bool {
+	for _, a := range actions {
+		if a == action {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,50 @@
+// Package policy defines Pike's provider-neutral internal representation
+// of the permissions a piece of infrastructure-as-code requires. It exists
+// so the bootstrap-generation packages (classify, transform, validate, ...)
+// depend on this stable shape rather than reaching into Pike's own
+// scan-result types directly — keeping Pike's mappings separable for
+// upstream synchronization (see spec section 20.2).
+package policy
+
+// Policy is the permissions required to deploy a Terraform/OpenTofu
+// configuration, as produced by an Analyzer (see internal/scan).
+type Policy struct {
+	Statements []Statement
+}
+
+// Statement groups one or more actions under a shared resource scope. A
+// Policy returned from scanning source code is always an implicit "Allow" —
+// deny semantics are introduced later, during deploy-boundary
+// transformation, not at scan time.
+type Statement struct {
+	Actions   []string
+	Resources []string
+}
+
+// Actions returns every action across all statements, deduplicated but
+// unsorted (callers that need a stable order should sort the result).
+func (p Policy) Actions() []string {
+	seen := make(map[string]bool)
+
+	var actions []string
+
+	for _, statement := range p.Statements {
+		for _, action := range statement.Actions {
+			if seen[action] {
+				continue
+			}
+
+			seen[action] = true
+
+			actions = append(actions, action)
+		}
+	}
+
+	return actions
+}
+
+// Empty reports whether the policy has no statements, i.e. the scanned
+// source required no permissions.
+func (p Policy) Empty() bool {
+	return len(p.Statements) == 0
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,68 @@
+package policy_test
+
+import (
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/policy"
+)
+
+func TestPolicy_Actions_Deduplicates(t *testing.T) {
+	t.Parallel()
+
+	p := policy.Policy{
+		Statements: []policy.Statement{
+			{Actions: []string{"ec2:DescribeInstances", "ec2:RunInstances"}, Resources: []string{"*"}},
+			{Actions: []string{"ec2:DescribeInstances", "iam:PassRole"}, Resources: []string{"*"}},
+		},
+	}
+
+	got := p.Actions()
+
+	want := map[string]bool{
+		"ec2:DescribeInstances": false,
+		"ec2:RunInstances":      false,
+		"iam:PassRole":          false,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("Actions() = %v, want %d unique actions", got, len(want))
+	}
+
+	for _, a := range got {
+		if _, ok := want[a]; !ok {
+			t.Errorf("Actions() contains unexpected action %q", a)
+		}
+
+		want[a] = true
+	}
+
+	for action, seen := range want {
+		if !seen {
+			t.Errorf("Actions() is missing %q", action)
+		}
+	}
+}
+
+func TestPolicy_Empty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    policy.Policy
+		want bool
+	}{
+		{"no statements", policy.Policy{}, true},
+		{"one statement", policy.Policy{Statements: []policy.Statement{{Actions: []string{"ec2:DescribeInstances"}}}}, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.p.Empty(); got != tt.want {
+				t.Errorf("Empty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -1,0 +1,75 @@
+// Package scan adapts Pike's existing Terraform/OpenTofu analysis into
+// Pike's provider-neutral internal Policy model (see internal/policy).
+// Pike v0.1 targets AWS only, so the Analyzer here always scans for AWS
+// permissions regardless of what other providers appear in the source.
+package scan
+
+import (
+	"context"
+
+	"github.com/jameswoolfenden/pike/internal/policy"
+	pike "github.com/jameswoolfenden/pike/src"
+)
+
+// awsProvider selects AWS-only resources out of MakePermissionBag's
+// mixed-provider scan; Pike v0.1 has no use for GCP/Azure permissions.
+const awsProvider = "aws"
+
+// Analyzer scans a Terraform/OpenTofu directory and returns the
+// permissions it requires as a provider-neutral Policy.
+type Analyzer interface {
+	Scan(ctx context.Context, directory string) (policy.Policy, error)
+}
+
+// PikeAnalyzer is the default Analyzer, backed by Pike's Terraform parser
+// and AWS resource-to-permission mappings. It never runs `terraform init`
+// and never requires AWS credentials — generation is static analysis only
+// (spec section 20.2).
+type PikeAnalyzer struct{}
+
+// Scan implements Analyzer.
+func (PikeAnalyzer) Scan(ctx context.Context, directory string) (policy.Policy, error) {
+	if err := ctx.Err(); err != nil {
+		return policy.Policy{}, err
+	}
+
+	const (
+		init               = false
+		suppressDeprecated = false
+	)
+
+	bag, err := pike.MakePermissionBag(directory, nil, init, awsProvider, suppressDeprecated)
+	if err != nil {
+		if pike.IsEmptyIAC(err) {
+			return policy.Policy{}, nil
+		}
+
+		return policy.Policy{}, err
+	}
+
+	if len(bag.AWS) == 0 {
+		return policy.Policy{}, nil
+	}
+
+	// resources=false: no live AWS account to build real ARNs from, so
+	// every statement gets Resource ["*"] grouped by AWS service prefix.
+	pikePolicy, err := pike.NewAWSPolicy(bag.AWS, false)
+	if err != nil {
+		return policy.Policy{}, err
+	}
+
+	return fromPikePolicy(pikePolicy), nil
+}
+
+func fromPikePolicy(p pike.Policy) policy.Policy {
+	statements := make([]policy.Statement, 0, len(p.Statements))
+
+	for _, s := range p.Statements {
+		statements = append(statements, policy.Statement{
+			Actions:   s.Action,
+			Resources: s.Resource,
+		})
+	}
+
+	return policy.Policy{Statements: statements}
+}

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -1,0 +1,74 @@
+package scan_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jameswoolfenden/pike/internal/scan"
+)
+
+func TestPikeAnalyzer_Scan(t *testing.T) {
+	t.Parallel()
+
+	var analyzer scan.PikeAnalyzer
+
+	p, err := analyzer.Scan(context.Background(), "testdata/aws_security_group")
+	if err != nil {
+		t.Fatalf("Scan() error = %v, want nil", err)
+	}
+
+	if p.Empty() {
+		t.Fatal("Scan() returned an empty policy, want the aws_security_group permissions")
+	}
+
+	actions := p.Actions()
+
+	want := "ec2:CreateSecurityGroup"
+	found := false
+
+	for _, a := range actions {
+		if a == want {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Scan() actions = %v, want it to contain %q", actions, want)
+	}
+
+	for _, s := range p.Statements {
+		if len(s.Resources) != 1 || s.Resources[0] != "*" {
+			t.Errorf("Statement.Resources = %v, want [\"*\"] (no AWS account context is available at scan time)", s.Resources)
+		}
+	}
+}
+
+func TestPikeAnalyzer_Scan_EmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	var analyzer scan.PikeAnalyzer
+
+	p, err := analyzer.Scan(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("Scan() error = %v, want nil for a directory with no Terraform files", err)
+	}
+
+	if !p.Empty() {
+		t.Errorf("Scan() = %+v, want an empty policy", p)
+	}
+}
+
+func TestPikeAnalyzer_Scan_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var analyzer scan.PikeAnalyzer
+
+	if _, err := analyzer.Scan(ctx, "testdata/aws_security_group"); err == nil {
+		t.Fatal("Scan() error = nil, want context.Canceled to be surfaced")
+	}
+}

--- a/internal/scan/testdata/aws_security_group/main.tf
+++ b/internal/scan/testdata/aws_security_group/main.tf
@@ -1,0 +1,21 @@
+resource "aws_security_group" "example" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = "vpc-0c33dc8cd64f408c4"
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jameswoolfenden/pike/internal/bootstrap"
 	"github.com/jameswoolfenden/pike/internal/parse"
 	pike "github.com/jameswoolfenden/pike/src"
 	"github.com/rs/zerolog"
@@ -37,6 +38,7 @@ func main() {
 		provider           string
 		outfile            string
 		policyName         string
+		bootstrapConfig    string
 	)
 
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
@@ -256,6 +258,28 @@ func main() {
 				},
 				Action: func(c *cli.Context) error {
 					return pike.Audit(directory, output, pike.ParseSeverity(c.String("min-severity")))
+				},
+			},
+			{
+				Name:  "bootstrap",
+				Usage: "EXPERIMENTAL: generate a safe AWS IAM deploy-role bootstrap (permissions boundary + MFA trust policy) from a pike.yaml config",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "directory",
+						Aliases:     []string{"d"},
+						Usage:       "Directory to scan (defaults to .)",
+						Value:       ".",
+						Destination: &directory,
+					},
+					&cli.StringFlag{
+						Name:        "config",
+						Usage:       "Path to the bootstrap config file",
+						Value:       "pike.yaml",
+						Destination: &bootstrapConfig,
+					},
+				},
+				Action: func(*cli.Context) error {
+					return bootstrap.Run(directory, bootstrapConfig)
 				},
 			},
 			{

--- a/src/error.go
+++ b/src/error.go
@@ -1,6 +1,7 @@
 package pike
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -362,6 +363,16 @@ type emptyIACError struct{}
 
 func (m *emptyIACError) Error() string {
 	return "no IAC found"
+}
+
+// IsEmptyIAC reports whether err indicates the scanned directory contained
+// no infrastructure-as-code to derive permissions from. Callers that want
+// to treat "nothing to scan" as an empty result rather than a hard failure
+// (as Scan does) can check this before surfacing err.
+func IsEmptyIAC(err error) bool {
+	var e *emptyIACError
+
+	return errors.As(err, &e)
 }
 
 type makePolicyError struct {

--- a/testdata/bootstrap/ecs-task-role/expected/assume-role-policy.json
+++ b/testdata/bootstrap/ecs-task-role/expected/assume-role-policy.json
@@ -1,0 +1,15 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-deploy/TerraformDeployRole"
+      ],
+      "Sid": "AssumeTerraformDeployRole"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/ecs-task-role/expected/deploy-boundary.json
+++ b/testdata/bootstrap/ecs-task-role/expected/deploy-boundary.json
@@ -96,8 +96,22 @@
     },
     {
       "Action": [
-        "iam:DeleteRole",
         "iam:PutRolePermissionsBoundary"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:PermissionsBoundary": "arn:aws:iam::123456789012:policy/boundaries/TerraformWorkloadBoundary"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "MaintainRequiredBoundary"
+    },
+    {
+      "Action": [
+        "iam:DeleteRole"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/testdata/bootstrap/ecs-task-role/expected/deploy-boundary.json
+++ b/testdata/bootstrap/ecs-task-role/expected/deploy-boundary.json
@@ -1,0 +1,140 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:CreateRole"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:PermissionsBoundary": "arn:aws:iam::123456789012:policy/boundaries/TerraformWorkloadBoundary"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "CreateRoleWithRequiredBoundary"
+    },
+    {
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:UpdateAccessKey"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyAccessKeyManagement"
+    },
+    {
+      "Action": [
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicy",
+        "iam:DeletePolicyVersion",
+        "iam:SetDefaultPolicyVersion"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:policy/boundaries/*"
+      ],
+      "Sid": "DenyBoundaryPolicyMutation"
+    },
+    {
+      "Action": [
+        "iam:CreateLoginProfile",
+        "iam:CreateUser",
+        "iam:CreateVirtualMFADevice",
+        "iam:DeactivateMFADevice",
+        "iam:DeleteLoginProfile",
+        "iam:DeleteUser",
+        "iam:DeleteVirtualMFADevice",
+        "iam:EnableMFADevice",
+        "iam:ResyncMFADevice",
+        "iam:UpdateLoginProfile",
+        "iam:UpdateUser"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyHumanPrincipalManagement"
+    },
+    {
+      "Action": [
+        "account:*",
+        "organizations:*"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyOrganizationManagement"
+    },
+    {
+      "Action": [
+        "iam:DeleteRolePermissionsBoundary"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "DenyWorkloadBoundaryRemoval"
+    },
+    {
+      "Action": [
+        "iam:GetRole",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
+        "iam:ListRolePolicies"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "IAMRead"
+    },
+    {
+      "Action": [
+        "iam:DeleteRole",
+        "iam:PutRolePermissionsBoundary"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "ManageTerraformRoles"
+    },
+    {
+      "Action": [
+        "ecs:DeregisterTaskDefinition",
+        "ecs:DescribeTaskDefinition",
+        "ecs:ListTagsForResource",
+        "ecs:RegisterTaskDefinition"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "NonIAM0"
+    },
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": [
+            "ecs-tasks.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "PassManagedRolesToApprovedServices"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/ecs-task-role/expected/deploy-policy.json
+++ b/testdata/bootstrap/ecs-task-role/expected/deploy-policy.json
@@ -1,0 +1,34 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ecs:DeregisterTaskDefinition",
+        "ecs:DescribeTaskDefinition",
+        "ecs:ListTagsForResource",
+        "ecs:RegisterTaskDefinition"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DeployPolicy0"
+    },
+    {
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
+        "iam:ListRolePolicies",
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DeployPolicy1"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/ecs-task-role/expected/report.json
+++ b/testdata/bootstrap/ecs-task-role/expected/report.json
@@ -1,0 +1,45 @@
+{
+  "artifacts": {
+    "deploy_boundary": "sha256:7037b7ad30f774393792d88033c0671e1a7c2d94abb9235b74bc67fd8b0f91bb",
+    "deploy_policy": "sha256:d0420c144cf497cdff9447c34cc8a332b9eb4abca511ab9c148846e56d275881",
+    "workload_boundary": "sha256:838c911da43aa22dd29ccf7c4280a2cb77ab35287bd3b6a84c3370fe5d210afd"
+  },
+  "generated_at": "2026-07-30T00:00:00Z",
+  "generator": {
+    "name": "pike",
+    "version": "0.1.0"
+  },
+  "inputs": {
+    "config_hash": "sha256:1fe80a1f8886bbe604bcd61649becc62fd05fddd732a885d5ffb12591c8bcacb",
+    "terraform_directory": "./terraform"
+  },
+  "rewrites": [
+    {
+      "action": "iam:CreateRole",
+      "classification": "role-create",
+      "rule": "CreateRoleWithRequiredBoundary"
+    },
+    {
+      "action": "iam:DeleteRole",
+      "classification": "role-policy-write",
+      "rule": "ManageTerraformRoles"
+    },
+    {
+      "action": "iam:PassRole",
+      "classification": "pass-role",
+      "rule": "PassManagedRolesToApprovedServices"
+    }
+  ],
+  "scanner": {
+    "mapping_revision": "test",
+    "name": "pike"
+  },
+  "schema_version": 1,
+  "summary": {
+    "blocking_findings": 0,
+    "escalation_actions": 3,
+    "iam_actions": 7,
+    "total_actions": 11
+  },
+  "warnings": null
+}

--- a/testdata/bootstrap/ecs-task-role/expected/report.json
+++ b/testdata/bootstrap/ecs-task-role/expected/report.json
@@ -1,6 +1,6 @@
 {
   "artifacts": {
-    "deploy_boundary": "sha256:7037b7ad30f774393792d88033c0671e1a7c2d94abb9235b74bc67fd8b0f91bb",
+    "deploy_boundary": "sha256:3e0a22630ab4f5d481d44806d3bceeec4672bc055b8e8faafc69c7da36735ac6",
     "deploy_policy": "sha256:d0420c144cf497cdff9447c34cc8a332b9eb4abca511ab9c148846e56d275881",
     "workload_boundary": "sha256:838c911da43aa22dd29ccf7c4280a2cb77ab35287bd3b6a84c3370fe5d210afd"
   },

--- a/testdata/bootstrap/ecs-task-role/expected/trust-policy.json
+++ b/testdata/bootstrap/ecs-task-role/expected/trust-policy.json
@@ -1,0 +1,21 @@
+{
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "NumericLessThanEquals": {
+          "aws:MultiFactorAuthAge": "3600"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:user/cli-user"
+      },
+      "Sid": "AssumeWithMFA"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/ecs-task-role/expected/workload-boundary.json
+++ b/testdata/bootstrap/ecs-task-role/expected/workload-boundary.json
@@ -1,0 +1,16 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "TerraformWorkloadBoundary"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/ecs-task-role/pike.yaml
+++ b/testdata/bootstrap/ecs-task-role/pike.yaml
@@ -1,0 +1,57 @@
+version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: us-east-1
+
+principal:
+  type: iam-user
+  name: cli-user
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/cli-user
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - logs:CreateLogStream
+      - logs:PutLogEvents
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  fail_on_unknown_iam_action: true
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false

--- a/testdata/bootstrap/ecs-task-role/terraform/main.tf
+++ b/testdata/bootstrap/ecs-task-role/terraform/main.tf
@@ -1,0 +1,30 @@
+resource "aws_iam_role" "task" {
+  name = "security-platform-task"
+  path = "/terraform-managed/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "security-platform"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.task.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([{
+    name  = "app"
+    image = "nginx:latest"
+  }])
+}

--- a/testdata/bootstrap/managed-policy/README.md
+++ b/testdata/bootstrap/managed-policy/README.md
@@ -1,0 +1,17 @@
+# managed-policy fixture
+
+No `terraform/` directory: this fixture uses a synthetic `policy.Policy`
+(`iam:CreatePolicyVersion`) defined directly in the test, rather than a
+scanned Terraform resource. Pike's `aws_iam_policy` mapping doesn't
+naturally produce `CreatePolicyVersion`/`SetDefaultPolicyVersion`/etc.
+(those are provider-internal calls on policy update, not something the
+static resource mapping models), so constructing the input directly is
+more reliable than hunting for a real resource that happens to trigger it.
+
+This fixture demonstrates that deploy-boundary generation denies a
+policy-mutation action outright even though the deploy policy "requests"
+it — `deploy-policy.json` includes `iam:CreatePolicyVersion`, but
+`deploy-boundary.json` has no matching Allow statement anywhere, only the
+mandatory `DenyBoundaryPolicyMutation` deny. That's the
+"deploy policy = what's requested, deploy boundary = maximum safe
+delegation" split (spec section 11) working as intended.

--- a/testdata/bootstrap/managed-policy/expected/assume-role-policy.json
+++ b/testdata/bootstrap/managed-policy/expected/assume-role-policy.json
@@ -1,0 +1,15 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-deploy/TerraformDeployRole"
+      ],
+      "Sid": "AssumeTerraformDeployRole"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/managed-policy/expected/deploy-boundary.json
+++ b/testdata/bootstrap/managed-policy/expected/deploy-boundary.json
@@ -1,0 +1,71 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:UpdateAccessKey"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyAccessKeyManagement"
+    },
+    {
+      "Action": [
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicy",
+        "iam:DeletePolicyVersion",
+        "iam:SetDefaultPolicyVersion"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:policy/boundaries/*"
+      ],
+      "Sid": "DenyBoundaryPolicyMutation"
+    },
+    {
+      "Action": [
+        "iam:CreateLoginProfile",
+        "iam:CreateUser",
+        "iam:CreateVirtualMFADevice",
+        "iam:DeactivateMFADevice",
+        "iam:DeleteLoginProfile",
+        "iam:DeleteUser",
+        "iam:DeleteVirtualMFADevice",
+        "iam:EnableMFADevice",
+        "iam:ResyncMFADevice",
+        "iam:UpdateLoginProfile",
+        "iam:UpdateUser"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyHumanPrincipalManagement"
+    },
+    {
+      "Action": [
+        "account:*",
+        "organizations:*"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyOrganizationManagement"
+    },
+    {
+      "Action": [
+        "iam:DeleteRolePermissionsBoundary"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "DenyWorkloadBoundaryRemoval"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/managed-policy/expected/deploy-policy.json
+++ b/testdata/bootstrap/managed-policy/expected/deploy-policy.json
@@ -1,0 +1,15 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:CreatePolicyVersion"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DeployPolicy0"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/managed-policy/expected/report.json
+++ b/testdata/bootstrap/managed-policy/expected/report.json
@@ -1,0 +1,29 @@
+{
+  "artifacts": {
+    "deploy_boundary": "sha256:e17e8b5b22e8b8eefe367a5afc9d9c0897752373fc56d4e68923e7f8def3aea3",
+    "deploy_policy": "sha256:b4703cff9382ddb9943f783c4f22355c57f2406a36e38662ed4493f176cbbb27",
+    "workload_boundary": "sha256:838c911da43aa22dd29ccf7c4280a2cb77ab35287bd3b6a84c3370fe5d210afd"
+  },
+  "generated_at": "2026-07-30T00:00:00Z",
+  "generator": {
+    "name": "pike",
+    "version": "0.1.0"
+  },
+  "inputs": {
+    "config_hash": "sha256:1fe80a1f8886bbe604bcd61649becc62fd05fddd732a885d5ffb12591c8bcacb",
+    "terraform_directory": "./terraform"
+  },
+  "rewrites": null,
+  "scanner": {
+    "mapping_revision": "test",
+    "name": "pike"
+  },
+  "schema_version": 1,
+  "summary": {
+    "blocking_findings": 0,
+    "escalation_actions": 1,
+    "iam_actions": 1,
+    "total_actions": 1
+  },
+  "warnings": null
+}

--- a/testdata/bootstrap/managed-policy/expected/trust-policy.json
+++ b/testdata/bootstrap/managed-policy/expected/trust-policy.json
@@ -1,0 +1,21 @@
+{
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "NumericLessThanEquals": {
+          "aws:MultiFactorAuthAge": "3600"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:user/cli-user"
+      },
+      "Sid": "AssumeWithMFA"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/managed-policy/expected/workload-boundary.json
+++ b/testdata/bootstrap/managed-policy/expected/workload-boundary.json
@@ -1,0 +1,16 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "TerraformWorkloadBoundary"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/managed-policy/pike.yaml
+++ b/testdata/bootstrap/managed-policy/pike.yaml
@@ -1,0 +1,57 @@
+version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: us-east-1
+
+principal:
+  type: iam-user
+  name: cli-user
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/cli-user
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - logs:CreateLogStream
+      - logs:PutLogEvents
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  fail_on_unknown_iam_action: true
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false

--- a/testdata/bootstrap/no-iam/expected/assume-role-policy.json
+++ b/testdata/bootstrap/no-iam/expected/assume-role-policy.json
@@ -1,0 +1,15 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-deploy/TerraformDeployRole"
+      ],
+      "Sid": "AssumeTerraformDeployRole"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/no-iam/expected/deploy-boundary.json
+++ b/testdata/bootstrap/no-iam/expected/deploy-boundary.json
@@ -1,0 +1,88 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:UpdateAccessKey"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyAccessKeyManagement"
+    },
+    {
+      "Action": [
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicy",
+        "iam:DeletePolicyVersion",
+        "iam:SetDefaultPolicyVersion"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:policy/boundaries/*"
+      ],
+      "Sid": "DenyBoundaryPolicyMutation"
+    },
+    {
+      "Action": [
+        "iam:CreateLoginProfile",
+        "iam:CreateUser",
+        "iam:CreateVirtualMFADevice",
+        "iam:DeactivateMFADevice",
+        "iam:DeleteLoginProfile",
+        "iam:DeleteUser",
+        "iam:DeleteVirtualMFADevice",
+        "iam:EnableMFADevice",
+        "iam:ResyncMFADevice",
+        "iam:UpdateLoginProfile",
+        "iam:UpdateUser"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyHumanPrincipalManagement"
+    },
+    {
+      "Action": [
+        "account:*",
+        "organizations:*"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyOrganizationManagement"
+    },
+    {
+      "Action": [
+        "iam:DeleteRolePermissionsBoundary"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "DenyWorkloadBoundaryRemoval"
+    },
+    {
+      "Action": [
+        "ec2:CreateVPC",
+        "ec2:DeleteVPC",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyVpcAttribute",
+        "ec2:ModifyVpcTenancy"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "NonIAM0"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/no-iam/expected/deploy-policy.json
+++ b/testdata/bootstrap/no-iam/expected/deploy-policy.json
@@ -1,0 +1,22 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ec2:CreateVPC",
+        "ec2:DeleteVPC",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyVpcAttribute",
+        "ec2:ModifyVpcTenancy"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DeployPolicy0"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/no-iam/expected/report.json
+++ b/testdata/bootstrap/no-iam/expected/report.json
@@ -1,0 +1,29 @@
+{
+  "artifacts": {
+    "deploy_boundary": "sha256:9826d8600388e691e6516e11da58e8cadbd2ed163be56e99ff8b872822bcc352",
+    "deploy_policy": "sha256:48548d138fd857d3093bb7404f33adaeb65a9cc48861594aa2850d8ae76f21f2",
+    "workload_boundary": "sha256:838c911da43aa22dd29ccf7c4280a2cb77ab35287bd3b6a84c3370fe5d210afd"
+  },
+  "generated_at": "2026-07-30T00:00:00Z",
+  "generator": {
+    "name": "pike",
+    "version": "0.1.0"
+  },
+  "inputs": {
+    "config_hash": "sha256:1fe80a1f8886bbe604bcd61649becc62fd05fddd732a885d5ffb12591c8bcacb",
+    "terraform_directory": "./terraform"
+  },
+  "rewrites": null,
+  "scanner": {
+    "mapping_revision": "test",
+    "name": "pike"
+  },
+  "schema_version": 1,
+  "summary": {
+    "blocking_findings": 0,
+    "escalation_actions": 0,
+    "iam_actions": 0,
+    "total_actions": 8
+  },
+  "warnings": null
+}

--- a/testdata/bootstrap/no-iam/expected/trust-policy.json
+++ b/testdata/bootstrap/no-iam/expected/trust-policy.json
@@ -1,0 +1,21 @@
+{
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "NumericLessThanEquals": {
+          "aws:MultiFactorAuthAge": "3600"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:user/cli-user"
+      },
+      "Sid": "AssumeWithMFA"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/no-iam/expected/workload-boundary.json
+++ b/testdata/bootstrap/no-iam/expected/workload-boundary.json
@@ -1,0 +1,16 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "TerraformWorkloadBoundary"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/no-iam/pike.yaml
+++ b/testdata/bootstrap/no-iam/pike.yaml
@@ -1,0 +1,57 @@
+version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: us-east-1
+
+principal:
+  type: iam-user
+  name: cli-user
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/cli-user
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - logs:CreateLogStream
+      - logs:PutLogEvents
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  fail_on_unknown_iam_action: true
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false

--- a/testdata/bootstrap/no-iam/terraform/main.tf
+++ b/testdata/bootstrap/no-iam/terraform/main.tf
@@ -1,0 +1,3 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}

--- a/testdata/bootstrap/service-linked-role/expected/assume-role-policy.json
+++ b/testdata/bootstrap/service-linked-role/expected/assume-role-policy.json
@@ -1,0 +1,15 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-deploy/TerraformDeployRole"
+      ],
+      "Sid": "AssumeTerraformDeployRole"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/service-linked-role/expected/deploy-boundary.json
+++ b/testdata/bootstrap/service-linked-role/expected/deploy-boundary.json
@@ -1,0 +1,99 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": [
+            "ecs.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "CreateApprovedServiceLinkedRoles"
+    },
+    {
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:UpdateAccessKey"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyAccessKeyManagement"
+    },
+    {
+      "Action": [
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicy",
+        "iam:DeletePolicyVersion",
+        "iam:SetDefaultPolicyVersion"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:policy/boundaries/*"
+      ],
+      "Sid": "DenyBoundaryPolicyMutation"
+    },
+    {
+      "Action": [
+        "iam:CreateLoginProfile",
+        "iam:CreateUser",
+        "iam:CreateVirtualMFADevice",
+        "iam:DeactivateMFADevice",
+        "iam:DeleteLoginProfile",
+        "iam:DeleteUser",
+        "iam:DeleteVirtualMFADevice",
+        "iam:EnableMFADevice",
+        "iam:ResyncMFADevice",
+        "iam:UpdateLoginProfile",
+        "iam:UpdateUser"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyHumanPrincipalManagement"
+    },
+    {
+      "Action": [
+        "account:*",
+        "organizations:*"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DenyOrganizationManagement"
+    },
+    {
+      "Action": [
+        "iam:DeleteRolePermissionsBoundary"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/terraform-managed/*"
+      ],
+      "Sid": "DenyWorkloadBoundaryRemoval"
+    },
+    {
+      "Action": [
+        "iam:GetRole",
+        "iam:GetServiceLinkedRoleDeletionStatus"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "IAMRead"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/service-linked-role/expected/deploy-policy.json
+++ b/testdata/bootstrap/service-linked-role/expected/deploy-policy.json
@@ -1,0 +1,19 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "iam:DeleteServiceLinkedRole",
+        "iam:GetRole",
+        "iam:GetServiceLinkedRoleDeletionStatus",
+        "iam:UpdateRoleDescription"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DeployPolicy0"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/service-linked-role/expected/report.json
+++ b/testdata/bootstrap/service-linked-role/expected/report.json
@@ -1,0 +1,35 @@
+{
+  "artifacts": {
+    "deploy_boundary": "sha256:6fda33e23b7bf0d8740c5a246639d2a035903da3b09b52c14ef6e19dc541b5ac",
+    "deploy_policy": "sha256:044e216285b861dde9eee3e6d0443d901c285d6315e3e714664ab1d475213be9",
+    "workload_boundary": "sha256:838c911da43aa22dd29ccf7c4280a2cb77ab35287bd3b6a84c3370fe5d210afd"
+  },
+  "generated_at": "2026-07-30T00:00:00Z",
+  "generator": {
+    "name": "pike",
+    "version": "0.1.0"
+  },
+  "inputs": {
+    "config_hash": "sha256:c34fe2d3569807623d879fa9966ad199d05cb6d12a328c8fa64f6873cf7916b5",
+    "terraform_directory": "./terraform"
+  },
+  "rewrites": [
+    {
+      "action": "iam:CreateServiceLinkedRole",
+      "classification": "service-linked-role",
+      "rule": "CreateApprovedServiceLinkedRoles"
+    }
+  ],
+  "scanner": {
+    "mapping_revision": "test",
+    "name": "pike"
+  },
+  "schema_version": 1,
+  "summary": {
+    "blocking_findings": 0,
+    "escalation_actions": 3,
+    "iam_actions": 5,
+    "total_actions": 5
+  },
+  "warnings": null
+}

--- a/testdata/bootstrap/service-linked-role/expected/trust-policy.json
+++ b/testdata/bootstrap/service-linked-role/expected/trust-policy.json
@@ -1,0 +1,21 @@
+{
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "NumericLessThanEquals": {
+          "aws:MultiFactorAuthAge": "3600"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:user/cli-user"
+      },
+      "Sid": "AssumeWithMFA"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/service-linked-role/expected/workload-boundary.json
+++ b/testdata/bootstrap/service-linked-role/expected/workload-boundary.json
@@ -1,0 +1,16 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "TerraformWorkloadBoundary"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/service-linked-role/pike.yaml
+++ b/testdata/bootstrap/service-linked-role/pike.yaml
@@ -1,0 +1,63 @@
+version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: us-east-1
+
+principal:
+  type: iam-user
+  name: cli-user
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/cli-user
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - logs:CreateLogStream
+      - logs:PutLogEvents
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  # aws_iam_service_linked_role's modify/destroy mappings include
+  # iam:DeleteServiceLinkedRole, which the classifier doesn't recognize
+  # (spec's taxonomy has no entry for it). This fixture demonstrates the
+  # happy-path CreateServiceLinkedRole boundary statement, so unknown
+  # actions are dropped rather than failing generation; see the
+  # unknown-iam-action fixture for the fail-closed behavior itself.
+  fail_on_unknown_iam_action: false
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false

--- a/testdata/bootstrap/service-linked-role/terraform/main.tf
+++ b/testdata/bootstrap/service-linked-role/terraform/main.tf
@@ -1,0 +1,3 @@
+resource "aws_iam_service_linked_role" "ecs" {
+  aws_service_name = "ecs.amazonaws.com"
+}

--- a/testdata/bootstrap/unknown-iam-action/README.md
+++ b/testdata/bootstrap/unknown-iam-action/README.md
@@ -1,0 +1,15 @@
+# unknown-iam-action fixture
+
+No `terraform/` directory: this fixture uses a synthetic `policy.Policy`
+(`iam:UpdateAssumeRolePolicy`, an IAM write the classifier doesn't
+recognize) defined directly in the test, rather than a scanned Terraform
+resource — no readily available Pike-mapped resource produces exactly
+this action on its own, and constructing the input directly keeps the
+fixture precisely targeted at the fail-closed path.
+
+Generation is expected to fail at the deploy-boundary stage
+(`*transform.UnknownIAMActionError`), so `expected/` only contains
+`deploy-policy.json` — the one artifact that gets rendered before the
+pipeline stops. There is no `deploy-boundary.json`, `workload-boundary.json`,
+`trust-policy.json`, `assume-role-policy.json` or `report.json` for this
+fixture.

--- a/testdata/bootstrap/unknown-iam-action/expected/deploy-policy.json
+++ b/testdata/bootstrap/unknown-iam-action/expected/deploy-policy.json
@@ -1,0 +1,15 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:UpdateAssumeRolePolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": "DeployPolicy0"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/testdata/bootstrap/unknown-iam-action/pike.yaml
+++ b/testdata/bootstrap/unknown-iam-action/pike.yaml
@@ -1,0 +1,57 @@
+version: 1
+
+aws:
+  account_id: "123456789012"
+  partition: aws
+  region: us-east-1
+
+principal:
+  type: iam-user
+  name: cli-user
+  mfa:
+    required: true
+    serial: arn:aws:iam::123456789012:mfa/cli-user
+    max_age_seconds: 3600
+
+deploy_role:
+  name: TerraformDeployRole
+  path: /terraform-deploy/
+  max_session_duration: 3600
+
+managed_roles:
+  path: /terraform-managed/
+
+policies:
+  deploy:
+    name: TerraformDeployPolicy
+    path: /terraform-deploy/
+  deploy_boundary:
+    name: TerraformDeployBoundary
+    path: /boundaries/
+  workload_boundary:
+    name: TerraformWorkloadBoundary
+    path: /boundaries/
+    mode: allowlist
+    allowed_actions:
+      - logs:CreateLogStream
+      - logs:PutLogEvents
+
+pass_role:
+  allowed_services:
+    - ecs-tasks.amazonaws.com
+
+service_linked_roles:
+  allowed_services:
+    - ecs.amazonaws.com
+
+security:
+  fail_on_unknown_iam_action: true
+  deny_boundary_removal: true
+  deny_boundary_policy_mutation: true
+  deny_human_principal_management: true
+  deny_access_key_management: true
+  deny_organization_management: true
+
+output:
+  directory: .pike/bootstrap
+  overwrite: false


### PR DESCRIPTION
## Summary

Brings in the AWS IAM bootstrap / permissions-boundary generator originally designed and built by **@qj0r9j0vc2** (Jinu) in his [rampart](https://github.com/qj0r9j0vc2/rampart) fork (reviewed via #163), fixed and rehomed as a new `pike bootstrap` command. Credit for the design and the bulk of the implementation goes to him - this PR fixes a real bug found in review, hardens the test coverage, and wires it into pike proper.

`pike bootstrap` generates a permissions-boundary-constrained AWS deploy role from pike's existing Terraform scan output, so a CI/deploy identity that needs `iam:CreateRole`/`iam:PassRole` can't use that access to escalate itself to account admin - a well-known privilege-escalation pattern for infra-deploying identities.

**This is marked Experimental** and is AWS-only. It closes the IAM self-escalation path specifically; it is **not** a least-privilege policy generator - non-IAM actions are still `Resource: ["*"]`, for the same reason the rest of pike's output already is (no live-AWS-state resource inference). See the README's "Bootstrap (Experimental)" section for the full caveat.

## What changed from the original fork PR

- **Fixed a privilege-escalation bug**: `iam:PutRolePermissionsBoundary` was granted with no condition on which boundary could be attached, while `iam:CreateRole` was correctly conditioned. A deploy role could bypass its boundary entirely by re-pointing a managed role at a different, attacker-controlled boundary policy - exactly the bypass the boundary-tampering denies exist to prevent. Fixed by giving it its own conditioned statement (`MaintainRequiredBoundary`), plus two new `validate.go` rules (RMP-E013/E014) and a hardened `DenyBoundaryPolicyMutation` scope.
- **Added adversarial regression tests** (`internal/bootstrap/transform/privesc_test.go`): a small in-process IAM evaluator that simulates actual escalation attempts against the generated policy (explicit-deny-wins, condition matching) rather than just checking action presence - including a calibration test proving the evaluator would have caught the original bug's exact shape. Manually verified `TestPrivesc_BoundarySwapBlocked` fails against the pre-fix code and passes after.
- **Renamed** `qj0r9j0vc2/rampart` → `jameswoolfenden/pike` import paths throughout, `rampart.yaml` → `pike.yaml`, default output directory `.rampart/bootstrap` → `.pike/bootstrap` (matching pike's existing `.pike` output convention).
- **Wired into the CLI**: new `pike bootstrap` command (`main.go`), a new `internal/bootstrap.Run` entry point driving the existing generate → validate → report pipeline, output written under `.pike/bootstrap/` (overridable via `pike.yaml`'s `output.directory`, `output.overwrite` guards against clobbering).
- **Documented** as an experimental feature in the README, with the least-privilege caveat front and center.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` clean, including new adversarial privesc tests
- [x] `golangci-lint run` clean (0 issues)
- [x] Manually built the binary and ran `pike bootstrap -d <fixture>` against the `ecs-task-role` testdata fixture - output matched the golden fixture exactly
- [x] Manually verified `output.overwrite: false` refuses to clobber a prior run
- [x] Manually verified the fix: stashed just the fix, confirmed `TestPrivesc_BoundarySwapBlocked` fails, restored, confirmed it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)