### PR TITLE
fix(gcp): populate empty App Engine permission mappings

### DIFF
--- a/src/gcp_test.go
+++ b/src/gcp_test.go
@@ -145,6 +145,142 @@ func TestGetGCPPermissions(t *testing.T) {
 	}
 }
 
+// TestGetGCPAppEnginePermissions covers the App Engine resource mappings
+// (mapping/google/resource/appengine/*.json) that previously shipped as
+// empty stubs -- apply/destroy/modify/plan all [] -- so any Terraform using
+// these resource types silently floored to zero required IAM permissions.
+// Verified against the official App Engine Admin API "Authorization
+// requires..." IAM permission for each REST method (apps.services.versions,
+// apps.domainMappings, apps.firewall.ingressRules).
+func TestGetGCPAppEnginePermissions(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		result ResourceV2
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "standard app version",
+			args: args{
+				result: ResourceV2{
+					TypeName: "resource", Name: "google_app_engine_standard_app_version",
+					Attributes: []string{"service", "runtime"},
+				},
+			},
+			want: []string{
+				"appengine.versions.create",
+				"appengine.versions.get",
+				"appengine.versions.update",
+				"appengine.versions.delete",
+				"appengine.versions.get",
+				"appengine.versions.update",
+				"appengine.versions.delete",
+			},
+		},
+		{
+			name: "flexible app version",
+			args: args{
+				result: ResourceV2{
+					TypeName: "resource", Name: "google_app_engine_flexible_app_version",
+					Attributes: []string{"service", "runtime"},
+				},
+			},
+			want: []string{
+				"appengine.versions.create",
+				"appengine.versions.get",
+				"appengine.versions.update",
+				"appengine.versions.delete",
+				"appengine.versions.get",
+				"appengine.versions.update",
+				"appengine.versions.delete",
+			},
+		},
+		{
+			name: "domain mapping",
+			args: args{
+				result: ResourceV2{
+					TypeName: "resource", Name: "google_app_engine_domain_mapping",
+					Attributes: []string{"domain_name"},
+				},
+			},
+			want: []string{
+				"appengine.applications.get",
+				"appengine.applications.update",
+				"appengine.applications.get",
+				"appengine.applications.update",
+				"appengine.applications.update",
+			},
+		},
+		{
+			name: "firewall rule",
+			args: args{
+				result: ResourceV2{
+					TypeName: "resource", Name: "google_app_engine_firewall_rule",
+					Attributes: []string{"priority", "action"},
+				},
+			},
+			want: []string{
+				"appengine.applications.get",
+				"appengine.applications.update",
+				"appengine.applications.get",
+				"appengine.applications.update",
+				"appengine.applications.update",
+			},
+		},
+		{
+			name: "application url dispatch rules",
+			args: args{
+				result: ResourceV2{
+					TypeName: "resource", Name: "google_app_engine_application_url_dispatch_rules",
+					Attributes: []string{"dispatch_rules"},
+				},
+			},
+			want: []string{
+				"appengine.applications.get",
+				"appengine.applications.update",
+				"appengine.applications.get",
+				"appengine.applications.update",
+			},
+		},
+		{
+			name: "service split traffic",
+			args: args{
+				result: ResourceV2{
+					TypeName: "resource", Name: "google_app_engine_service_split_traffic",
+					Attributes: []string{"service", "split"},
+				},
+			},
+			want: []string{
+				"appengine.services.update",
+				"appengine.services.get",
+				"appengine.services.get",
+				"appengine.services.update",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getGCPPermissions(tt.args.result)
+			if err != nil {
+				t.Fatalf("getGCPPermissions() unexpected error = %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getGCPPermissions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetGCPResourcePermissions(t *testing.T) {
 	t.Parallel()
 

--- a/src/mapping/google/resource/appengine/google_app_engine_application_url_dispatch_rules.json
+++ b/src/mapping/google/resource/appengine/google_app_engine_application_url_dispatch_rules.json
@@ -1,11 +1,18 @@
 [
   {
-    "apply": [],
+    "apply": [
+      "appengine.applications.get",
+      "appengine.applications.update"
+    ],
     "attributes": {
       "tags": []
     },
     "destroy": [],
-    "modify": [],
-    "plan": []
+    "modify": [
+      "appengine.applications.update"
+    ],
+    "plan": [
+      "appengine.applications.get"
+    ]
   }
 ]

--- a/src/mapping/google/resource/appengine/google_app_engine_domain_mapping.json
+++ b/src/mapping/google/resource/appengine/google_app_engine_domain_mapping.json
@@ -1,11 +1,20 @@
 [
   {
-    "apply": [],
+    "apply": [
+      "appengine.applications.get",
+      "appengine.applications.update"
+    ],
     "attributes": {
       "tags": []
     },
-    "destroy": [],
-    "modify": [],
-    "plan": []
+    "destroy": [
+      "appengine.applications.update"
+    ],
+    "modify": [
+      "appengine.applications.update"
+    ],
+    "plan": [
+      "appengine.applications.get"
+    ]
   }
 ]

--- a/src/mapping/google/resource/appengine/google_app_engine_firewall_rule.json
+++ b/src/mapping/google/resource/appengine/google_app_engine_firewall_rule.json
@@ -1,11 +1,20 @@
 [
   {
-    "apply": [],
+    "apply": [
+      "appengine.applications.get",
+      "appengine.applications.update"
+    ],
     "attributes": {
       "tags": []
     },
-    "destroy": [],
-    "modify": [],
-    "plan": []
+    "destroy": [
+      "appengine.applications.update"
+    ],
+    "modify": [
+      "appengine.applications.update"
+    ],
+    "plan": [
+      "appengine.applications.get"
+    ]
   }
 ]

--- a/src/mapping/google/resource/appengine/google_app_engine_flexible_app_version.json
+++ b/src/mapping/google/resource/appengine/google_app_engine_flexible_app_version.json
@@ -1,11 +1,22 @@
 [
   {
-    "apply": [],
+    "apply": [
+      "appengine.versions.create",
+      "appengine.versions.get",
+      "appengine.versions.update",
+      "appengine.versions.delete"
+    ],
     "attributes": {
       "tags": []
     },
-    "destroy": [],
-    "modify": [],
-    "plan": []
+    "destroy": [
+      "appengine.versions.delete"
+    ],
+    "modify": [
+      "appengine.versions.update"
+    ],
+    "plan": [
+      "appengine.versions.get"
+    ]
   }
 ]

--- a/src/mapping/google/resource/appengine/google_app_engine_service_split_traffic.json
+++ b/src/mapping/google/resource/appengine/google_app_engine_service_split_traffic.json
@@ -1,11 +1,18 @@
 [
   {
-    "apply": [],
+    "apply": [
+      "appengine.services.update",
+      "appengine.services.get"
+    ],
     "attributes": {
       "tags": []
     },
     "destroy": [],
-    "modify": [],
-    "plan": []
+    "modify": [
+      "appengine.services.update"
+    ],
+    "plan": [
+      "appengine.services.get"
+    ]
   }
 ]

--- a/src/mapping/google/resource/appengine/google_app_engine_standard_app_version.json
+++ b/src/mapping/google/resource/appengine/google_app_engine_standard_app_version.json
@@ -1,11 +1,22 @@
 [
   {
-    "apply": [],
+    "apply": [
+      "appengine.versions.create",
+      "appengine.versions.get",
+      "appengine.versions.update",
+      "appengine.versions.delete"
+    ],
     "attributes": {
       "tags": []
     },
-    "destroy": [],
-    "modify": [],
-    "plan": []
+    "destroy": [
+      "appengine.versions.delete"
+    ],
+    "modify": [
+      "appengine.versions.update"
+    ],
+    "plan": [
+      "appengine.versions.get"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- 6 of 8 `src/mapping/google/resource/appengine/*.json` files shipped as empty stubs (`apply`/`destroy`/`modify`/`plan` all `[]`): `google_app_engine_standard_app_version`, `_flexible_app_version`, `_domain_mapping`, `_firewall_rule`, `_application_url_dispatch_rules`, `_service_split_traffic`.
- Any Terraform using these resource types silently floored to **zero** required IAM permissions in `pike scan` output. Found while running the `pike-safe-policy` skill against `terraform-gcp-appengine`, a module built entirely around `google_app_engine_standard_app_version`.
- Permissions filled in are verified against the official App Engine Admin API docs (the "Authorization requires..." line on each REST method), not guessed:
  - `apps.services.versions.{create,get,update,delete}` -> `appengine.versions.*` (standard and flexible versions share the same underlying API resource)
  - `apps.domainMappings.{get,create,patch,delete}` -> `appengine.applications.{get,update}`
  - `apps.firewall.ingressRules.{get,create}` -> `appengine.applications.{get,update}`
  - `apps.patch` (dispatch rules) -> `appengine.applications.{get,update}`
  - `apps.services.patch` (split traffic) -> `appengine.services.{get,update}`

This is one slice of a larger, pre-existing gap -- 26 GCP mapping files across the repo currently have empty `apply` arrays (access-context-manager, apigee, beyondcorp, compute, datacatalog, dataflow, iam, kms, ...). Scoped this PR to the 8 App Engine files since those were blocking real work; the rest is a follow-up, not expanded here.

## Test plan
- [x] New `TestGetGCPAppEnginePermissions` in `src/gcp_test.go` covers all 6 previously-empty resource types
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] `pike scan -o split -d <terraform-gcp-appengine>` now correctly floors `appengine.versions.*` / `appengine.applications.*` instead of omitting them entirely
- [x] `pike deprecated -p google` confirms none of these resource types are provider-deprecated (ruled out as an alternative explanation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)